### PR TITLE
MNT: use commas in num formatting on CLI

### DIFF
--- a/metagenomescope/graph_objects/assembly_graph.py
+++ b/metagenomescope/graph_objects/assembly_graph.py
@@ -1499,7 +1499,7 @@ class AssemblyGraph(object):
 
             if cc_full_node_ct >= 5:
                 operation_msg(
-                    "Laying out component {} ({} nodes, {} edges)...".format(
+                    "Laying out component {:,} ({:,} nodes, {:,} edges)...".format(
                         cc_i, cc_full_node_ct, cc_full_edge_ct
                     )
                 )


### PR DESCRIPTION
at least for CC #'s and node/edge cts. looks nicer lol