### PR TITLE
Use a basic grid method for tiling components' bounding boxes; show "N/A" for missing attributes in info tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ big-list-of-naughty-strings/
 *.db
 *.png
 mg2/
+coverage/

--- a/metagenomescope/support_files/js/app-manager.js
+++ b/metagenomescope/support_files/js/app-manager.js
@@ -56,6 +56,10 @@ define(["jquery", "underscore", "drawer", "utils", "dom-utils"], function (
             // structure a row of node/edge data to add to these tables.)
             this.nodeInfoTableAttrs = [];
             this.edgeInfoTableAttrs = [];
+
+            // Text shown in selected element info tables for attributes not
+            // given for a node / edge / pattern.
+            this.ATTR_NA = "N/A";
         }
 
         /**
@@ -290,6 +294,7 @@ define(["jquery", "underscore", "drawer", "utils", "dom-utils"], function (
         }
 
         updateSelectedNodeInfo(eleID, selectOrUnselect) {
+            var scope = this;
             // TODO abstract across nodes/edges/patterns -- basically the same
             if (selectOrUnselect === "select") {
                 var nodeInfo = this.dataHolder.getNodeInfo(eleID);
@@ -308,27 +313,31 @@ define(["jquery", "underscore", "drawer", "utils", "dom-utils"], function (
                     var lowercaseattr = attr.toLowerCase();
                     var val = nodeInfo[nodeAttrs[attr]];
 
-                    if (attr === "length") {
-                        // Unlike the old version of MgSc, we just say every
-                        // length measure is in bp instead of trying to
-                        // distinguish nt from bp. I think this is kosher,
-                        // since it's not like we can tell if contigs are
-                        // oriented are not for general formats like GFA...?
-                        val = val.toLocaleString() + " bp";
-                    } else if (attr === "coverage" || attr === "depth") {
-                        // Show coverages with at most two decimal places worth
-                        // of precision, but less if possible. I will be
-                        // honest, this code is from the old MgSc and I have
-                        // no idea how I came up with this. wtf marcus 4 years
-                        // ago lol
-                        val = Math.round(val * 100) / 100 + "x";
-                    } else if (attr === "gc_content") {
-                        // GC content should be shown as a percentage, rounded
-                        // to two decimal places. We multiply by 10,000 because
-                        // we're really multiplying by 100 twice: first to
-                        // convert to a percentage, then to start the rounding
-                        // process.
-                        val = Math.round(val * 10000) / 100 + "%";
+                    if (_.isNull(val)) {
+                        val = scope.ATTR_NA;
+                    } else {
+                        if (attr === "length") {
+                            // Unlike the old version of MgSc, we just say every
+                            // length measure is in bp instead of trying to
+                            // distinguish nt from bp. I think this is kosher,
+                            // since it's not like we can tell if contigs are
+                            // oriented are not for general formats like GFA...?
+                            val = val.toLocaleString() + " bp";
+                        } else if (attr === "coverage" || attr === "depth") {
+                            // Show coverages with at most two decimal places worth
+                            // of precision, but less if possible. I will be
+                            // honest, this code is from the old MgSc and I have
+                            // no idea how I came up with this. wtf marcus 4 years
+                            // ago lol
+                            val = Math.round(val * 100) / 100 + "x";
+                        } else if (attr === "gc_content") {
+                            // GC content should be shown as a percentage, rounded
+                            // to two decimal places. We multiply by 10,000 because
+                            // we're really multiplying by 100 twice: first to
+                            // convert to a percentage, then to start the rounding
+                            // process.
+                            val = Math.round(val * 10000) / 100 + "%";
+                        }
                     }
                     rowHTML += "<td>" + val + "</td>";
                 });
@@ -372,6 +381,9 @@ define(["jquery", "underscore", "drawer", "utils", "dom-utils"], function (
                     } else {
                         // It's a "normal" attribute stored in the edge's data.
                         val = edgeInfo[edgeAttrs[attr]];
+                        if (_.isNull(val)) {
+                            val = scope.ATTR_NA;
+                        }
                     }
                     rowHTML += "<td>" + val + "</td>";
                 });

--- a/metagenomescope/support_files/js/drawer.js
+++ b/metagenomescope/support_files/js/drawer.js
@@ -552,7 +552,8 @@ define([
             } else {
                 classes += " M";
             }
-            var x = dx + (pattVals[pattAttrs.left] + pattVals[pattAttrs.right]) / 2;
+            var x =
+                dx + (pattVals[pattAttrs.left] + pattVals[pattAttrs.right]) / 2;
             var y =
                 dy - (pattVals[pattAttrs.bottom] + pattVals[pattAttrs.top]) / 2;
             this.cy.add({
@@ -977,12 +978,12 @@ define([
                 // to bottom and left to right.
                 if (_.isNull(firstCompWidth)) {
                     firstCompWidth = componentBoundingBox[0];
-                    dy -= (componentBoundingBox[1] + scope.COMPONENT_PADDING);
+                    dy -= componentBoundingBox[1] + scope.COMPONENT_PADDING;
                 } else {
-                    dx -= (componentBoundingBox[0] + scope.COMPONENT_PADDING);
+                    dx -= componentBoundingBox[0] + scope.COMPONENT_PADDING;
                     if (Math.abs(dx) > firstCompWidth) {
                         dx = 0;
-                        dy -= (componentBoundingBox[1] + scope.COMPONENT_PADDING);
+                        dy -= componentBoundingBox[1] + scope.COMPONENT_PADDING;
                     }
                 }
             });


### PR DESCRIPTION
Closes #191 and closes #192. Component tiling could still be improved, but I'll open up a new issue for that -- the fixes there will take a nontrivial amount of work (requires refactoring a lot of junk about how coordinates are transformed).