### PR TITLE
For now, just don't detect frayed ropes

### DIFF
--- a/metagenomescope/graph_objects/assembly_graph.py
+++ b/metagenomescope/graph_objects/assembly_graph.py
@@ -1130,11 +1130,6 @@ class AssemblyGraph(object):
                 (self.bubbles, AssemblyGraph.is_valid_3node_bubble, "bubble"),
                 (self.bubbles, AssemblyGraph.is_valid_bubble, "bubble"),
                 (self.bubbles, AssemblyGraph.is_valid_superbubble, "bubble"),
-                (
-                    self.frayed_ropes,
-                    AssemblyGraph.is_valid_frayed_rope,
-                    "frayedrope",
-                ),
             ):
                 # We sort the nodes in order to make this deterministic
                 # (I doubt the extra time cost from sorting will be a big deal)


### PR DESCRIPTION
Temporary way to avoid the bug described in #202, where frayed ropes in the decomposed graph could lead to "duplicate" edges -- which currently break the python code, resulting in these edges not showing up in the graph.

I plan to revert this when I can get a fix to #202 ready (ideally ASAP, but this is the end of the quarter / most stressful time of the year soooo ._.)