### PR TITLE
STY: Un-break CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ big-list-of-naughty-strings/
 *.gv
 *.xdot
 *.db
+*.agp
 mg2/
 coverage/
 metagenomescope/tests/input/extras/sheepgut_g1217.gfa

--- a/metagenomescope/tests/graph_objects/assembly_graph/pattern_detection/test_hierarchical_decomposition.py
+++ b/metagenomescope/tests/graph_objects/assembly_graph/pattern_detection/test_hierarchical_decomposition.py
@@ -113,12 +113,12 @@ def test_bubble_chain_identification():
     ag = AssemblyGraph("metagenomescope/tests/input/bubble_chain_test.gml")
     ag.hierarchically_identify_patterns()
     # TODO: Fix, as described above!
-    #assert len(ag.decomposed_digraph.nodes) == 1
-    #assert len(ag.decomposed_digraph.edges) == 0
-    #assert len(ag.chains) == 3
-    #assert len(ag.cyclic_chains) == 0
-    #assert len(ag.frayed_ropes) == 1
-    #assert len(ag.bubbles) == 0
+    # assert len(ag.decomposed_digraph.nodes) == 1
+    # assert len(ag.decomposed_digraph.edges) == 0
+    # assert len(ag.chains) == 3
+    # assert len(ag.cyclic_chains) == 0
+    # assert len(ag.frayed_ropes) == 1
+    # assert len(ag.bubbles) == 0
 
 
 def test_bubble_cyclic_chain_identification():

--- a/metagenomescope/tests/input/extras/rename_gfa.py
+++ b/metagenomescope/tests/input/extras/rename_gfa.py
@@ -7,7 +7,7 @@
 # CIGAR for links), which will obvs cause problems if this is applied to
 # arbitrary GFA files.
 
-with open("sheepgut_g1217.gfa", 'r') as f:
+with open("sheepgut_g1217.gfa", "r") as f:
     gfa = f.read()
 
 ot = ""
@@ -26,7 +26,7 @@ for line in gfa.splitlines():
         else:
             # Another line (... which I assume does not contain node
             # information)
-            ot += (line + "\n")
+            ot += line + "\n"
 
     else:
         # This is a "S" line (segment, aka node, even though if this is a de


### PR DESCRIPTION
I *think* this should make the CI now pass, subject to travis-ci.org playing nicely.

Weird situation where un-breaking the CI (commenting out a failing test for the pattern decomposition stuff; see #201, etc) ended up breaking the CI in a different way (the style-checker didn't like the way I commented the test out lol). :bread: