### PR TITLE
Make drawing nonredundant components a separate "modifier"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ this format is adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1
   - Currently, this contains controls that can be used to change how selected
     nodes are represented, and how wide various types of edges should be.
 
-- For the length x coverage scatterplot: using Plotly's box / lasso selection
+- For the length × coverage scatterplot: using Plotly's box / lasso selection
   tools in this plot now shows a list of all selected components
   ([#448](https://github.com/marbl/MetagenomeScope/issues/448)).
 
@@ -38,6 +38,27 @@ this format is adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1
   ([#439](https://github.com/marbl/MetagenomeScope/issues/439)).
 
 - Allow bipartites with parallel edges, to be consistent with frayed ropes.
+
+- Adjust the drawing options dialog, including splitting up `Modifiers` into
+  two sections (`What should we draw?` and `How should we draw it?`).
+
+- Replace the `Entire graph (nonredundant)` drawing method with a checkbox in
+  the drawing options dialog under the "Layout" section,
+  `Just nonredundant components`
+  ([#442](https://github.com/marbl/MetagenomeScope/issues/442)).
+
+  - Now, if you want to draw all components in the graph but filter to the
+    nonredundant ones, you can just select the `Entire graph (all components)`
+    drawing method, and this checkbox will indicate that we should filter these
+    components to the nonredundant ones.
+
+  - An advantage of making this setting a "modifier" (rather than its own
+    drawing method) is that this can be combined with the `Component(s)`
+    drawing methods. So, you could draw components `1-100` using the
+    `Component(s), by size rank` drawing method, and then the checkbox would
+    filter these components to only one component from each pair.
+    (This also works well with 
+    [#448](https://github.com/marbl/MetagenomeScope/issues/448).)
 
 - Adjust how nodes are scaled based on length
   ([#316](https://github.com/marbl/MetagenomeScope/issues/316)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,18 +47,14 @@ this format is adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1
   `Just nonredundant components`
   ([#442](https://github.com/marbl/MetagenomeScope/issues/442)).
 
-  - Now, if you want to draw all components in the graph but filter to the
-    nonredundant ones, you can just select the `Entire graph (all components)`
-    drawing method, and this checkbox will indicate that we should filter these
-    components to the nonredundant ones.
+  - If this checkbox is checked, then -- for the `Component(s), by size rank`,
+    `Component(s), by node name`, and `Entire graph (all components)` drawing
+    methods -- all pairs of redundant components in a draw request will be
+    filtered to just nonredundant components.
 
-  - An advantage of making this setting a "modifier" (rather than its own
-    drawing method) is that this can be combined with the `Component(s)`
-    drawing methods. So, you could draw components `1-100` using the
-    `Component(s), by size rank` drawing method, and then the checkbox would
-    filter these components to only one component from each pair.
-    (This also works well with 
-    [#448](https://github.com/marbl/MetagenomeScope/issues/448).)
+  - Making this setting a "modifier" (rather than its own drawing method)
+    enables some useful functionalities. In particular, it plays nicely with
+    [#448](https://github.com/marbl/MetagenomeScope/issues/448).
 
 - Adjust how nodes are scaled based on length
   ([#316](https://github.com/marbl/MetagenomeScope/issues/316)).

--- a/metagenomescope/cy_utils.py
+++ b/metagenomescope/cy_utils.py
@@ -377,7 +377,7 @@ def get_cyjs_stylesheet(
     return stylesheet
 
 
-def get_cyjs_layout_settings(layout_alg, draw_settings):
+def get_cyjs_layout_settings(layout_alg, modifier_settings):
     """Gets layout settings for Cytoscape.js for a given algorithm.
 
     This is just the stuff we pass to Cytoscape.js. To try to make the
@@ -387,7 +387,9 @@ def get_cyjs_layout_settings(layout_alg, draw_settings):
     """
 
     anim_settings = layout_config.ANIMATION_SETTINGS
-    anim_settings["animate"] = ui_config.DO_LAYOUT_ANIMATION in draw_settings
+    anim_settings["animate"] = (
+        ui_config.DO_LAYOUT_ANIMATION in modifier_settings
+    )
 
     if layout_alg == ui_config.LAYOUT_DAGRE:
         return {"name": "dagre", "rankDir": "LR", **anim_settings}

--- a/metagenomescope/graph/assembly_graph.py
+++ b/metagenomescope/graph/assembly_graph.py
@@ -2443,6 +2443,12 @@ class AssemblyGraph(object):
     def to_cyjs(self, done_flushing):
         """Converts the graph's elements to a Cytoscape.js-compatible format.
 
+        Note that, if the "just nonredundant components" setting is checked,
+        then that should already be reflected in done_flushing. (That is, if
+        the draw type was DRAW_CCS, then done_flushing["cc_nums"] should
+        already have been filtered; and if the draw type was DRAW_ALL, then
+        it should have been changed to DRAW_NR.)
+
         Parameters
         ----------
         done_flushing: dict
@@ -2470,25 +2476,10 @@ class AssemblyGraph(object):
         if doing_layout:
             log_utils.log_layout_start(done_flushing, self)
 
-        # figure out if we should only draw nonredundant components. That is,
-        # detect pairs of perfectly reverse-complementary components and just
-        # draw one of these components.
-        #
-        # This impacts the DRAW_ALL / DRAW_CCS options. DRAW_AROUND does not
-        # care about this, I think, by its nature.
-        just_nr_ccs = ui_utils.nr_ccs(scope_settings)
-
         if draw_type == config.DRAW_ALL:
             # draw all component(s)
             dr = DrawResults({}, scope_settings)
-            if just_nr_ccs:
-                # ok actually just draw the NR components
-                # use map() to avoid building up an extra list of Component
-                # objs all at once
-                ccs = map(self.get_cc_by_num, self.get_nr_cc_nums())
-            else:
-                ccs = self.components
-            for cc in ccs:
+            for cc in self.components:
                 dr += cc.to_cyjs(
                     scope_settings,
                     modifier_settings,
@@ -2499,32 +2490,21 @@ class AssemblyGraph(object):
         elif draw_type == config.DRAW_CCS:
             # draw certain component(s)
             dr = DrawResults({}, scope_settings)
-            if just_nr_ccs:
-                # draw just the components in the list, but also remove pairs
-                # of redundant components. If both a component and its twin are
-                # in the list, then draw whichever one of the two is in
-                # self.nr_cc_nums.
-                #
-                # make the list of input cc nums into a set to speed up lookups
-                requested_cc_nums_set = set(done_flushing["cc_nums"])
-                ccns = set()
-                for ccn in requested_cc_nums_set:
-                    if ccn in self.nr_cc_nums:
-                        ccns.add(ccn)
-                    else:
-                        # Even if ccn is not in self.nr_cc_nums (i.e. it has a
-                        # twin that IS in self.nr_cc_nums), if this twin is not
-                        # in the set of requested cc nums, then still draw ccn.
-                        if (
-                            self.ccnum2twinccnum[ccn]
-                            not in requested_cc_nums_set
-                        ):
-                            ccns.add(ccn)
-                        # if we've made it here, both ccn and its twin are in
-                        # the set of requested cc nums, so ignore ccn.
-            else:
-                ccns = done_flushing["cc_nums"]
-            for ccn in ccns:
+            for ccn in done_flushing["cc_nums"]:
+                cc = self.get_cc_by_num(ccn)
+                dr += cc.to_cyjs(
+                    scope_settings,
+                    modifier_settings,
+                    layout_alg,
+                    layout_params,
+                )
+
+        elif draw_type == config.DRAW_NR:
+            # draw all component(s), but only the nonredundant ones (so for
+            # each pair of perfectly reverse-complementary components, we'll
+            # just draw one of these)
+            dr = DrawResults({}, scope_settings)
+            for ccn in self.get_nr_cc_nums():
                 cc = self.get_cc_by_num(ccn)
                 dr += cc.to_cyjs(
                     scope_settings,

--- a/metagenomescope/graph/assembly_graph.py
+++ b/metagenomescope/graph/assembly_graph.py
@@ -397,6 +397,9 @@ class AssemblyGraph(object):
         # For things like MetaCarvel GML files, though, don't bother (leave
         # self.nr_cc_nums as None)
         self.nr_cc_nums = None
+        # If we detect nonredundant components, then update this dict: maps
+        # component size rank to the size rank of the twin component.
+        self.ccnum2twinccnum = {}
         if self.orientation_in_name:
             logger.debug(
                 "  Detecting pairs of redundant components, since this is a "
@@ -2088,12 +2091,16 @@ class AssemblyGraph(object):
                         self.nr_cc_nums.add(min(cc.cc_num, cc2_num))
                     else:
                         self.nr_cc_nums.add(cc2_num)
+                    self.ccnum2twinccnum[cc.cc_num] = cc2_num
+                    self.ccnum2twinccnum[cc2_num] = cc.cc_num
                     continue
 
             # If we're still here, then these components weren't twins.
             self.nr_cc_nums.add(cc.cc_num)
+            self.ccnum2twinccnum[cc.cc_num] = None
             if cc2_num is not None:
                 self.nr_cc_nums.add(cc2_num)
+                self.ccnum2twinccnum[cc2_num] = None
 
     def get_nr_cc_nums(self):
         """Returns the size ranks of all nonredundant components."""
@@ -2463,10 +2470,25 @@ class AssemblyGraph(object):
         if doing_layout:
             log_utils.log_layout_start(done_flushing, self)
 
+        # figure out if we should only draw nonredundant components. That is,
+        # detect pairs of perfectly reverse-complementary components and just
+        # draw one of these components.
+        #
+        # This impacts the DRAW_ALL / DRAW_CCS options. DRAW_AROUND does not
+        # care about this, I think, by its nature.
+        just_nr_ccs = ui_utils.nr_ccs(scope_settings)
+
         if draw_type == config.DRAW_ALL:
             # draw all component(s)
             dr = DrawResults({}, scope_settings)
-            for cc in self.components:
+            if just_nr_ccs:
+                # ok actually just draw the NR components
+                # use map() to avoid building up an extra list of Component
+                # objs all at once
+                ccs = map(self.get_cc_by_num, self.get_nr_cc_nums())
+            else:
+                ccs = self.components
+            for cc in ccs:
                 dr += cc.to_cyjs(
                     scope_settings,
                     modifier_settings,
@@ -2477,21 +2499,32 @@ class AssemblyGraph(object):
         elif draw_type == config.DRAW_CCS:
             # draw certain component(s)
             dr = DrawResults({}, scope_settings)
-            for ccn in done_flushing["cc_nums"]:
-                cc = self.get_cc_by_num(ccn)
-                dr += cc.to_cyjs(
-                    scope_settings,
-                    modifier_settings,
-                    layout_alg,
-                    layout_params,
-                )
-
-        elif draw_type == config.DRAW_NR:
-            # draw all component(s), but only the nonredundant ones (so for
-            # each pair of perfectly reverse-complementary components, we'll
-            # just draw one of these)
-            dr = DrawResults({}, scope_settings)
-            for ccn in self.get_nr_cc_nums():
+            if just_nr_ccs:
+                # draw just the components in the list, but also remove pairs
+                # of redundant components. If both a component and its twin are
+                # in the list, then draw whichever one of the two is in
+                # self.nr_cc_nums.
+                #
+                # make the list of input cc nums into a set to speed up lookups
+                requested_cc_nums_set = set(done_flushing["cc_nums"])
+                ccns = set()
+                for ccn in requested_cc_nums_set:
+                    if ccn in self.nr_cc_nums:
+                        ccns.add(ccn)
+                    else:
+                        # Even if ccn is not in self.nr_cc_nums (i.e. it has a
+                        # twin that IS in self.nr_cc_nums), if this twin is not
+                        # in the set of requested cc nums, then still draw ccn.
+                        if (
+                            self.ccnum2twinccnum[ccn]
+                            not in requested_cc_nums_set
+                        ):
+                            ccns.add(ccn)
+                        # if we've made it here, both ccn and its twin are in
+                        # the set of requested cc nums, so ignore ccn.
+            else:
+                ccns = done_flushing["cc_nums"]
+            for ccn in ccns:
                 cc = self.get_cc_by_num(ccn)
                 dr += cc.to_cyjs(
                     scope_settings,

--- a/metagenomescope/graph/assembly_graph.py
+++ b/metagenomescope/graph/assembly_graph.py
@@ -2357,7 +2357,7 @@ class AssemblyGraph(object):
         subgraph = nx.induced_subgraph(self.graph, subgraph_node_ids)
         return subgraph, subgraph_node_ids
 
-    def get_ids_in_neighborhood(self, node_ids, dist, draw_settings):
+    def get_ids_in_neighborhood(self, node_ids, dist, scope_settings):
         """Returns the IDs of all nodes, edges, and patterns in a neighborhood.
 
         See get_neighborhood()'s documentation for details. The main "extra"
@@ -2378,7 +2378,7 @@ class AssemblyGraph(object):
 
         # Get patterns, maybe
         subgraph_patt_ids = set()
-        if ui_utils.show_patterns(draw_settings):
+        if ui_utils.show_patterns(scope_settings):
             # include a pattern only if all its descendant nodes and edges are
             # included
             for pid, p in self.pattid2obj.items():
@@ -2403,11 +2403,17 @@ class AssemblyGraph(object):
         return subgraph_node_ids, subgraph_edge_ids, subgraph_patt_ids
 
     def _to_cyjs_around_nodes(
-        self, node_ids, dist, draw_settings, layout_alg, layout_params
+        self,
+        node_ids,
+        dist,
+        scope_settings,
+        modifier_settings,
+        layout_alg,
+        layout_params,
     ):
         """Produces Cytoscape.js elements only "around" certain nodes."""
         sel_node_ids, sel_edge_ids, sel_patt_ids = (
-            self.get_ids_in_neighborhood(node_ids, dist, draw_settings)
+            self.get_ids_in_neighborhood(node_ids, dist, scope_settings)
         )
         # NOTE: in theory, if a user draws around nodes multiple times then
         # we will just keep creating new subgraph ids. however, since diff
@@ -2423,7 +2429,9 @@ class AssemblyGraph(object):
             [self.edgeid2obj[i] for i in sel_edge_ids],
             [self.pattid2obj[i] for i in sel_patt_ids],
         )
-        return sg.to_cyjs(draw_settings, layout_alg, layout_params)
+        return sg.to_cyjs(
+            scope_settings, modifier_settings, layout_alg, layout_params
+        )
 
     def to_cyjs(self, done_flushing):
         """Converts the graph's elements to a Cytoscape.js-compatible format.
@@ -2446,7 +2454,8 @@ class AssemblyGraph(object):
         https://js.cytoscape.org/#notation/elements-json
         """
         draw_type = done_flushing["draw_type"]
-        draw_settings = done_flushing["draw_settings"]
+        scope_settings = done_flushing["scope_settings"]
+        modifier_settings = done_flushing["modifier_settings"]
         layout_alg = done_flushing["layout_alg"]
         layout_params = done_flushing["layout_params"]
 
@@ -2456,32 +2465,48 @@ class AssemblyGraph(object):
 
         if draw_type == config.DRAW_ALL:
             # draw all component(s)
-            dr = DrawResults({}, draw_settings)
+            dr = DrawResults({}, scope_settings)
             for cc in self.components:
-                dr += cc.to_cyjs(draw_settings, layout_alg, layout_params)
+                dr += cc.to_cyjs(
+                    scope_settings,
+                    modifier_settings,
+                    layout_alg,
+                    layout_params,
+                )
 
         elif draw_type == config.DRAW_CCS:
             # draw certain component(s)
-            dr = DrawResults({}, draw_settings)
+            dr = DrawResults({}, scope_settings)
             for ccn in done_flushing["cc_nums"]:
                 cc = self.get_cc_by_num(ccn)
-                dr += cc.to_cyjs(draw_settings, layout_alg, layout_params)
+                dr += cc.to_cyjs(
+                    scope_settings,
+                    modifier_settings,
+                    layout_alg,
+                    layout_params,
+                )
 
         elif draw_type == config.DRAW_NR:
             # draw all component(s), but only the nonredundant ones (so for
             # each pair of perfectly reverse-complementary components, we'll
             # just draw one of these)
-            dr = DrawResults({}, draw_settings)
+            dr = DrawResults({}, scope_settings)
             for ccn in self.get_nr_cc_nums():
                 cc = self.get_cc_by_num(ccn)
-                dr += cc.to_cyjs(draw_settings, layout_alg, layout_params)
+                dr += cc.to_cyjs(
+                    scope_settings,
+                    modifier_settings,
+                    layout_alg,
+                    layout_params,
+                )
 
         elif draw_type == config.DRAW_AROUND:
             # draw around certain node(s)
             dr = self._to_cyjs_around_nodes(
                 done_flushing["around_node_ids"],
                 done_flushing["around_dist"],
-                draw_settings,
+                scope_settings,
+                modifier_settings,
                 layout_alg,
                 layout_params,
             )

--- a/metagenomescope/graph/draw_results.py
+++ b/metagenomescope/graph/draw_results.py
@@ -8,7 +8,7 @@ from . import graph_utils
 class DrawResults(object):
     """Takes care of preparing Cytoscape.js JSON elements to be drawn."""
 
-    def __init__(self, region2layout, draw_settings):
+    def __init__(self, region2layout, scope_settings):
         """Initializes this DrawResults object.
 
         Parameters
@@ -17,15 +17,16 @@ class DrawResults(object):
             Can be {}. I guess that's useful if you want to define an instance
             of this to which you'll later add other DrawResults objects.
 
-        draw_settings: list
+        scope_settings: list
+            Describes what to draw (e.g. should we draw patterns?)
 
         Notes
         -----
         The region2layout thing exploits the fact that Subgraphs are hashable.
         """
         self.region2layout = region2layout
-        self.draw_settings = draw_settings
-        self.incl_patterns = ui_utils.show_patterns(self.draw_settings)
+        self.scope_settings = scope_settings
+        self.incl_patterns = ui_utils.show_patterns(self.scope_settings)
 
         # if we see even a single layout that is None, we will immediately give
         # up on processing layouts. In practice we should never see mix-and-
@@ -51,7 +52,7 @@ class DrawResults(object):
     def __repr__(self):
         asum = self.get_fancy_count_text()
         rsum = ui_utils.pluralize(len(self.region2layout), "region")
-        return f"DrawResults({rsum} ({asum}); {self.draw_settings})"
+        return f"DrawResults({rsum} ({asum}); {self.scope_settings})"
 
     def get_node_and_edge_ids(self):
         nodeids = []
@@ -65,8 +66,8 @@ class DrawResults(object):
 
     def __add__(self, other):
         """Adds two DrawResults objects and does some validation."""
-        if self.draw_settings != other.draw_settings:
-            raise WeirdError(f"Incompatible draw settings: {self}, {other}")
+        if self.scope_settings != other.scope_settings:
+            raise WeirdError(f"Incompatible scope settings: {self}, {other}")
 
         if set(self.region2layout) & set(other.region2layout):
             raise WeirdError(
@@ -80,7 +81,7 @@ class DrawResults(object):
         d = self.region2layout.copy()
         for r, lay in other.region2layout.items():
             d[r] = lay
-        return DrawResults(d, self.draw_settings)
+        return DrawResults(d, self.scope_settings)
 
     def get_sorted_regions(self):
         """Sorts all of the regions represented here.
@@ -113,8 +114,8 @@ class DrawResults(object):
     def get_nolayout_eles(self):
         eles = []
         for r in self.region2layout:
-            eles.extend(n.to_cyjs(self.draw_settings) for n in r.nodes)
-            eles.extend(e.to_cyjs(self.draw_settings) for e in r.edges)
+            eles.extend(n.to_cyjs(self.scope_settings) for n in r.nodes)
+            eles.extend(e.to_cyjs(self.scope_settings) for e in r.edges)
             if self.incl_patterns:
                 eles.extend(p.to_cyjs() for p in r.patterns)
         return eles
@@ -328,13 +329,13 @@ class DrawResults(object):
             nodeid2xy, edgeid2ctrlpts = lay.to_abs_coords(x, y)
 
             for n in r.nodes:
-                j = n.to_cyjs(self.draw_settings)
+                j = n.to_cyjs(self.scope_settings)
                 nx, ny = nodeid2xy[n.unique_id]
                 j["position"] = {"x": nx, "y": ny}
                 eles.append(j)
 
             for e in r.edges:
-                j = e.to_cyjs(self.draw_settings)
+                j = e.to_cyjs(self.scope_settings)
                 if e.unique_id in edgeid2ctrlpts:
                     straight, cpd, cpw = edgeid2ctrlpts[e.unique_id]
                     if not straight:

--- a/metagenomescope/graph/edge.py
+++ b/metagenomescope/graph/edge.py
@@ -248,7 +248,7 @@ class Edge(object):
             src, tgt, self.is_fake, is_back, indent
         )
 
-    def to_cyjs(self, draw_settings):
+    def to_cyjs(self, scope_settings):
         ele = {
             "data": {
                 "source": str(self.new_src_id),
@@ -271,7 +271,7 @@ class Edge(object):
                 ele["data"]["color"] = color
 
         if (
-            ui_utils.show_patterns(draw_settings)
+            ui_utils.show_patterns(scope_settings)
             and self.parent_id is not None
         ):
             ele["data"]["parent"] = str(self.parent_id)

--- a/metagenomescope/graph/node.py
+++ b/metagenomescope/graph/node.py
@@ -232,7 +232,7 @@ class Node(object):
     def to_dot(self, indent=layout_config.INDENT):
         return self.layout.to_dot(self.unique_id, self.name, indent)
 
-    def to_cyjs(self, draw_settings):
+    def to_cyjs(self, scope_settings):
         if "orientation" in self.data:
             if self.data["orientation"] == config.FWD:
                 ndir = "fwd"
@@ -262,7 +262,7 @@ class Node(object):
         )
 
         if (
-            ui_utils.show_patterns(draw_settings)
+            ui_utils.show_patterns(scope_settings)
             and self.parent_id is not None
         ):
             ele["data"]["parent"] = str(self.parent_id)

--- a/metagenomescope/graph/subgraph.py
+++ b/metagenomescope/graph/subgraph.py
@@ -173,12 +173,15 @@ class Subgraph(object):
                 ct += 1
         return ct
 
-    def to_cyjs(self, draw_settings, layout_alg, layout_params):
+    def to_cyjs(
+        self, scope_settings, modifier_settings, layout_alg, layout_params
+    ):
         """Creates Cytoscape.js elements for all nodes/edges in this subgraph.
 
         Parameters
         ----------
-        draw_settings: list
+        scope_settings: list
+        modifier_settings: list
             Various draw settings (show patterns?, do recursive layout?, etc.)
 
         layout_alg: str
@@ -194,5 +197,11 @@ class Subgraph(object):
         """
         lay = None
         if layout_alg in ui_config.LAYOUT2GVPROG:
-            lay = Layout(self, draw_settings, layout_alg, layout_params)
-        return DrawResults({self: lay}, draw_settings)
+            lay = Layout(
+                self,
+                scope_settings,
+                modifier_settings,
+                layout_alg,
+                layout_params,
+            )
+        return DrawResults({self: lay}, scope_settings)

--- a/metagenomescope/layout/layout.py
+++ b/metagenomescope/layout/layout.py
@@ -12,24 +12,27 @@ class Layout(object):
     a subregion of the graph, etc.
     """
 
-    def __init__(self, region, draw_settings, alg, params):
+    def __init__(self, region, scope_settings, modifier_settings, alg, params):
         """Initializes this Layout object.
 
         Parameters
         ----------
         region: Subgraph or Pattern
 
-        draw_settings: list
+        scope_settings: list
+
+        modifier_settings: list
 
         alg: str
 
         params: dict
         """
         self.region = region
-        self.draw_settings = draw_settings
-        self.incl_patterns = ui_utils.show_patterns(draw_settings)
-        self.recursive = ui_utils.do_recursive_layout(draw_settings)
-        self.use_gv_ports = ui_utils.use_gv_ports(draw_settings)
+        self.scope_settings = scope_settings
+        self.modifier_settings = modifier_settings
+        self.incl_patterns = ui_utils.show_patterns(scope_settings)
+        self.recursive = ui_utils.do_recursive_layout(modifier_settings)
+        self.use_gv_ports = ui_utils.use_gv_ports(modifier_settings)
         self.params = params
 
         if alg not in ui_config.LAYOUT2GVPROG:
@@ -77,7 +80,8 @@ class Layout(object):
     def __repr__(self):
         return (
             "Layout("
-            f"{self.region}; {self.draw_settings}; {self.alg}; {self.params}"
+            f"{self.region}; {self.scope_settings}; {self.modiifer_settings}; "
+            f"{self.alg}; {self.params}"
             ")"
         )
 
@@ -129,7 +133,11 @@ class Layout(object):
                     if node.compound:
                         # "node" is a collapsed pattern; lay it out first
                         lay = Layout(
-                            node, self.draw_settings, self.alg, self.params
+                            node,
+                            self.scope_settings,
+                            self.modifier_settings,
+                            self.alg,
+                            self.params,
                         )
                         dot += lay.to_solid_dot()
                         self.nodeid2rel.update(lay.nodeid2rel)
@@ -159,7 +167,11 @@ class Layout(object):
                 for pattern in self.region.patterns:
                     if self.at_top_level_of_region(pattern):
                         lay = Layout(
-                            pattern, self.draw_settings, self.alg, self.params
+                            pattern,
+                            self.scope_settings,
+                            self.modifier_settings,
+                            self.alg,
+                            self.params,
                         )
                         dot += lay.to_solid_dot()
                         self.nodeid2rel.update(lay.nodeid2rel)

--- a/metagenomescope/layout/layout_config.py
+++ b/metagenomescope/layout/layout_config.py
@@ -134,7 +134,7 @@ CLUSTER_PADDING = 10
 #
 # (Actually controlling "animate" - whether or not we do animation at all -
 # is controlled by a checkbox, which is controlled by
-# ui_config.DEFAULT_DRAW_SETTINGS)
+# ui_config.DEFAULT_MODIFIER_SETTINGS)
 ANIMATION_SETTINGS = {
     "animationDuration": 500,
 }

--- a/metagenomescope/log_utils.py
+++ b/metagenomescope/log_utils.py
@@ -48,8 +48,9 @@ def start_log(verbose: bool):
 
 
 def log_layout_start(done_flushing, ag):
-    draw_settings = done_flushing["draw_settings"]
-    st = "; ".join(draw_settings)
+    st = "; ".join(
+        done_flushing["scope_settings"] + done_flushing["modifier_settings"]
+    )
     for pk, pv in done_flushing["layout_params"].items():
         if len(st) > 0:
             st += "; "

--- a/metagenomescope/log_utils.py
+++ b/metagenomescope/log_utils.py
@@ -61,5 +61,5 @@ def log_layout_start(done_flushing, ag):
         st = f" ({st})"
 
     logging.debug(
-        f"  Laying out {thing} with {done_flushing['layout_alg']}{st}..."
+        f"  Laying out ({thing}) with {done_flushing['layout_alg']}{st}..."
     )

--- a/metagenomescope/main.py
+++ b/metagenomescope/main.py
@@ -175,10 +175,6 @@ def run(
                 "Around certain node(s)",
             ),
         ],
-        "ccDrawingNR": [
-            html.I(className="bi bi-arrow-right"),
-            html.Span("Entire graph (nonredundant)"),
-        ],
         "ccDrawingAll": [
             html.I(className="bi bi-asterisk"),
             html.Span(f"Entire graph ({all_cc_desc})"),
@@ -198,14 +194,14 @@ def run(
         CC_SELECTION_A_CLASSES_MULTIPLE_CCS += " disabled"
         CC_SELECTION_A_ATTRS_MULTIPLE_CCS = {"aria-disabled": "true"}
 
-    NR_CC_SELECTION_A_CLASSES = DEFAULT_CC_SELECTION_A_CLASSES
-    NR_CC_SELECTION_A_ATTRS = DEFAULT_CC_SELECTION_A_ATTRS
-    # Drawing only the nonredundant parts of the graph only makes sense if
-    # (1) there are pairs of nodes/edges X and -X in the graph (i.e.
-    # ag.orientation_in_name is True) and (2) there are multiple components.
-    if not (ag.orientation_in_name and multiple_ccs):
-        NR_CC_SELECTION_A_CLASSES += " disabled"
-        NR_CC_SELECTION_A_ATTRS = {"aria-disabled": "true"}
+    # NR_CC_SELECTION_A_CLASSES = DEFAULT_CC_SELECTION_A_CLASSES
+    # NR_CC_SELECTION_A_ATTRS = DEFAULT_CC_SELECTION_A_ATTRS
+    # # Drawing only the nonredundant parts of the graph only makes sense if
+    # # (1) there are pairs of nodes/edges X and -X in the graph (i.e.
+    # # ag.orientation_in_name is True) and (2) there are multiple components.
+    # if not (ag.orientation_in_name and multiple_ccs):
+    #     NR_CC_SELECTION_A_CLASSES += " disabled"
+    #     NR_CC_SELECTION_A_ATTRS = {"aria-disabled": "true"}
 
     NO_COMPONENTS_SELECTED_MSG = html.Span(
         [
@@ -515,16 +511,6 @@ def run(
                                                 ],
                                                 className="dropdown-item",
                                                 id="ccDrawingAroundNodes",
-                                            ),
-                                        ),
-                                        html.Li(
-                                            html.A(
-                                                cc_selection_options[
-                                                    "ccDrawingNR"
-                                                ],
-                                                className=NR_CC_SELECTION_A_CLASSES,
-                                                id="ccDrawingNR",
-                                                **NR_CC_SELECTION_A_ATTRS,
                                             ),
                                         ),
                                         html.Li(
@@ -2405,13 +2391,10 @@ def run(
         Input("ccDrawingSizeRank", "n_clicks"),
         Input("ccDrawingNodeNames", "n_clicks"),
         Input("ccDrawingAroundNodes", "n_clicks"),
-        Input("ccDrawingNR", "n_clicks"),
         Input("ccDrawingAll", "n_clicks"),
         prevent_initial_call=True,
     )
-    def change_drawing_method(
-        sr_clicks, nn_clicks, an_clicks, nr_clicks, all_clicks
-    ):
+    def change_drawing_method(sr_clicks, nn_clicks, an_clicks, all_clicks):
         # figure out which UI elements to show / hide
         # (note that the "nonredundant" and "all components" drawing methods
         # mean that there should be no additional UI elements displayed, which
@@ -2682,13 +2665,14 @@ def run(
 
     @callback(
         Output("dotAlgDesc", "children"),
-        Output("drawSettingsChecklist", "options"),
-        Input("drawSettingsChecklist", "value"),
+        Output("modifierSettingsChecklist", "options"),
+        Input("scopeSettingsChecklist", "value"),
+        Input("modifierSettingsChecklist", "value"),
         prevent_initial_call=True,
     )
-    def update_recursive_layout_plans(draw_settings):
-        show_patts = ui_config.SHOW_PATTERNS in draw_settings
-        do_rec_layout = ui_config.DO_RECURSIVE_LAYOUT in draw_settings
+    def update_recursive_layout_plans(scope_settings, modifier_settings):
+        show_patts = ui_utils.show_patterns(scope_settings)
+        do_rec_layout = ui_utils.do_recursive_layout(modifier_settings)
 
         if show_patts and do_rec_layout:
             desc = DOT_ALG_DESC_PATTS
@@ -2696,13 +2680,13 @@ def run(
             desc = DOT_ALG_DESC
 
         if not show_patts:
-            opts = copy.deepcopy(ui_config.DRAW_SETTINGS_OPTIONS)
+            opts = copy.deepcopy(ui_config.MODIFIER_SETTINGS_OPTIONS)
             for o in opts:
                 if o["value"] == ui_config.DO_RECURSIVE_LAYOUT:
                     o["disabled"] = True
                     break
         else:
-            opts = ui_config.DRAW_SETTINGS_OPTIONS
+            opts = ui_config.MODIFIER_SETTINGS_OPTIONS
 
         return desc, opts
 
@@ -2717,7 +2701,8 @@ def run(
         State("ccNodeNameSelector", "value"),
         State("ccAroundNodesNameSelector", "value"),
         State("ccAroundNodesDistSelector", "value"),
-        State("drawSettingsChecklist", "value"),
+        State("scopeSettingsChecklist", "value"),
+        State("modifierSettingsChecklist", "value"),
         State("dotRanksep", "value"),
         State("sfdpK", "value"),
         State("sfdpOverlapScaling", "value"),
@@ -2737,7 +2722,8 @@ def run(
         node_names,
         around_nodes_names,
         around_nodes_dist,
-        draw_settings,
+        scope_settings,
+        modifier_settings,
         dot_ranksep,
         sfdp_k,
         sfdp_overlap_scaling,
@@ -2824,14 +2810,6 @@ def run(
                 )
             draw_type = config.DRAW_AROUND
 
-        elif cc_drawing_selection_type == "ccDrawingNR":
-            # use a different draw type than DRAW_CCS, which will let us
-            # show a more concise summary of what is drawn than listing out
-            # something like "#1; #3; #5; ..."
-            # (also, no need to set "cc_nums = ag.get_nr_cc_nums()", since the
-            # AssemblyGraph will just see DRAW_NR and know to look those up)
-            draw_type = config.DRAW_NR
-
         elif cc_drawing_selection_type == "ccDrawingAll":
             draw_type = config.DRAW_ALL
 
@@ -2848,7 +2826,7 @@ def run(
             )
 
         cyjs_layout_settings = cy_utils.get_cyjs_layout_settings(
-            layout_alg, draw_settings
+            layout_alg, modifier_settings
         )
 
         try:
@@ -2926,7 +2904,8 @@ def run(
                 "cc_nums": cc_nums,
                 "around_node_ids": around_node_ids,
                 "around_dist": around_dist,
-                "draw_settings": draw_settings,
+                "scope_settings": scope_settings,
+                "modifier_settings": modifier_settings,
                 "layout_alg": layout_alg,
                 "layout_params": {
                     ui_config.LAYOUT_DOT: {
@@ -3334,15 +3313,6 @@ def run(
         elif curr_drawn_info["draw_type"] == config.DRAW_CCS:
             # only certain component(s) are drawn
             curr_drawn_cc_nums = set(curr_drawn_info["cc_nums"])
-            for n, c in nn2ccnum.items():
-                if c in curr_drawn_cc_nums:
-                    drawn_nodes.append(n)
-                else:
-                    undrawn_nodes.append(n)
-
-        elif curr_drawn_info["draw_type"] == config.DRAW_NR:
-            # only certain component(s) are drawn
-            curr_drawn_cc_nums = set(ag.get_nr_cc_nums())
             for n, c in nn2ccnum.items():
                 if c in curr_drawn_cc_nums:
                     drawn_nodes.append(n)

--- a/metagenomescope/main.py
+++ b/metagenomescope/main.py
@@ -194,15 +194,6 @@ def run(
         CC_SELECTION_A_CLASSES_MULTIPLE_CCS += " disabled"
         CC_SELECTION_A_ATTRS_MULTIPLE_CCS = {"aria-disabled": "true"}
 
-    # NR_CC_SELECTION_A_CLASSES = DEFAULT_CC_SELECTION_A_CLASSES
-    # NR_CC_SELECTION_A_ATTRS = DEFAULT_CC_SELECTION_A_ATTRS
-    # # Drawing only the nonredundant parts of the graph only makes sense if
-    # # (1) there are pairs of nodes/edges X and -X in the graph (i.e.
-    # # ag.orientation_in_name is True) and (2) there are multiple components.
-    # if not (ag.orientation_in_name and multiple_ccs):
-    #     NR_CC_SELECTION_A_CLASSES += " disabled"
-    #     NR_CC_SELECTION_A_ATTRS = {"aria-disabled": "true"}
-
     NO_COMPONENTS_SELECTED_MSG = html.Span(
         [
             "No components selected. You can use the ",
@@ -1747,7 +1738,10 @@ def run(
                             [
                                 dbc.Tab(
                                     ui_utils.get_layout_options_tab(
-                                        ag.node_centric, default_dot_alg_desc
+                                        ag.node_centric,
+                                        ag.orientation_in_name,
+                                        multiple_ccs,
+                                        default_dot_alg_desc,
                                     ),
                                     label="Layout",
                                 ),

--- a/metagenomescope/main.py
+++ b/metagenomescope/main.py
@@ -2742,6 +2742,7 @@ def run(
         )
 
         cc_nums = []
+        orig_cc_nums = []
         around_node_ids = []
         around_dist = 0
         draw_type = None
@@ -2869,9 +2870,59 @@ def run(
                 {"requestGood": False},
             )
 
+        # Account for the "Just nonredundant components" option, if checked
+        if ui_utils.nr_ccs(scope_settings):
+            if draw_type == config.DRAW_CCS:
+                # draw just the components in the list, but also remove pairs
+                # of redundant components. If both a component and its twin
+                # are in the list, then draw whichever one of the two is in
+                # ag.nr_cc_nums.
+                filtered_cc_nums = set()
+                for ccn in cc_nums:
+                    if ccn in ag.nr_cc_nums:
+                        filtered_cc_nums.add(ccn)
+                    else:
+                        # Even if ccn is not in ag.nr_cc_nums (i.e. it has a
+                        # twin that IS in ag.nr_cc_nums): if its twin is not in
+                        # cc_nums (i.e. it was not explicitly requested), then
+                        # draw ccn
+                        if ag.ccnum2twinccnum[ccn] not in cc_nums:
+                            filtered_cc_nums.add(ccn)
+                        # if we've made it here, both ccn and its twin were
+                        # explicitly requested (i.e. in cc_nums), so ignore ccn
+                        # in favor of its twin in ag.nr_cc_nums
+
+                if filtered_cc_nums == ag.nr_cc_nums:
+                    # if the user entered in something silly like "1-" to draw
+                    # all ccs then just reduce this to DRAW_NR to say that
+                    # more clearly (now no need to store this stuff)
+                    cc_nums = []
+                    draw_type = config.DRAW_NR
+                else:
+                    # Otherwise, actually store the filtered cc nums. Save a
+                    # copy of the original cc nums for showing in the
+                    # currently-drawn text, etc (but don't bother if filtering
+                    # didn't change anything)
+                    if cc_nums != filtered_cc_nums:
+                        orig_cc_nums = list(cc_nums)
+                    cc_nums = filtered_cc_nums
+
+            elif draw_type == config.DRAW_ALL:
+                # just draw all nonredundant components
+                #
+                # use a different draw type than DRAW_CCS, which will let us
+                # show a more concise summary of what is drawn than listing out
+                # something like "#1; #3; #5; ..." (and a more accurate summary
+                # than saying #1 -- |Components| like we would for DRAW_ALL).
+                #
+                # (also, no need to set "cc_nums = ag.get_nr_cc_nums()", since
+                # the AssemblyGraph will just see DRAW_NR and know to look
+                # those up)
+                draw_type = config.DRAW_NR
+
         # cc_nums has to be JSON-serializable (it might be a set at this point)
-        # (and if we are drawing around nodes instead of drawing entire ccs,
-        # then this will just be []. and that's beautiful. not really)
+        # (and don't worry; if we are not using DRAW_CCS, then this will just
+        # be []. and that's beautiful. not really)
         cc_nums = list(cc_nums)
 
         # Okay, now we've done enough checks that this request to draw the
@@ -2896,6 +2947,7 @@ def run(
                 "requestGood": True,
                 "draw_type": draw_type,
                 "cc_nums": cc_nums,
+                "orig_cc_nums": orig_cc_nums,
                 "around_node_ids": around_node_ids,
                 "around_dist": around_dist,
                 "scope_settings": scope_settings,
@@ -3304,15 +3356,6 @@ def run(
             # everything is drawn
             drawn_nodes = list(nn2ccnum.keys())
 
-        elif curr_drawn_info["draw_type"] == config.DRAW_CCS:
-            # only certain component(s) are drawn
-            curr_drawn_cc_nums = set(curr_drawn_info["cc_nums"])
-            for n, c in nn2ccnum.items():
-                if c in curr_drawn_cc_nums:
-                    drawn_nodes.append(n)
-                else:
-                    undrawn_nodes.append(n)
-
         elif curr_drawn_info["draw_type"] == config.DRAW_AROUND:
             # some weird subregion of the graph is drawn, as specified in
             # currDrawnInfo
@@ -3327,7 +3370,18 @@ def run(
                 raise WeirdError(f"No node IDs available in {curr_drawn_info}")
 
         else:
-            raise WeirdError(f"Unrecognized draw type: {curr_drawn_info}")
+            # only certain component(s) are drawn
+            if curr_drawn_info["draw_type"] == config.DRAW_CCS:
+                curr_drawn_cc_nums = set(curr_drawn_info["cc_nums"])
+            elif curr_drawn_info["draw_type"] == config.DRAW_NR:
+                curr_drawn_cc_nums = set(ag.get_nr_cc_nums())
+            else:
+                raise WeirdError(f"Unrecognized draw type: {curr_drawn_info}")
+            for n, c in nn2ccnum.items():
+                if c in curr_drawn_cc_nums:
+                    drawn_nodes.append(n)
+                else:
+                    undrawn_nodes.append(n)
 
         # If none of these nodes are currently drawn, show an error.
         if len(drawn_nodes) == 0:

--- a/metagenomescope/main.py
+++ b/metagenomescope/main.py
@@ -2741,8 +2741,8 @@ def run(
             "Received request to draw the graph. Validating request."
         )
 
-        cc_nums = []
-        orig_cc_nums = []
+        cc_nums = set()
+        orig_cc_nums = set()
         around_node_ids = []
         around_dist = 0
         draw_type = None
@@ -2870,60 +2870,15 @@ def run(
                 {"requestGood": False},
             )
 
-        # Account for the "Just nonredundant components" option, if checked
-        if ui_utils.nr_ccs(scope_settings):
-            if draw_type == config.DRAW_CCS:
-                # draw just the components in the list, but also remove pairs
-                # of redundant components. If both a component and its twin
-                # are in the list, then draw whichever one of the two is in
-                # ag.nr_cc_nums.
-                filtered_cc_nums = set()
-                for ccn in cc_nums:
-                    if ccn in ag.nr_cc_nums:
-                        filtered_cc_nums.add(ccn)
-                    else:
-                        # Even if ccn is not in ag.nr_cc_nums (i.e. it has a
-                        # twin that IS in ag.nr_cc_nums): if its twin is not in
-                        # cc_nums (i.e. it was not explicitly requested), then
-                        # draw ccn
-                        if ag.ccnum2twinccnum[ccn] not in cc_nums:
-                            filtered_cc_nums.add(ccn)
-                        # if we've made it here, both ccn and its twin were
-                        # explicitly requested (i.e. in cc_nums), so ignore ccn
-                        # in favor of its twin in ag.nr_cc_nums
+        draw_type, cc_nums, orig_cc_nums = ui_utils.nrfilter_draw_request(
+            scope_settings, draw_type, cc_nums, ag
+        )
 
-                if filtered_cc_nums == ag.nr_cc_nums:
-                    # if the user entered in something silly like "1-" to draw
-                    # all ccs then just reduce this to DRAW_NR to say that
-                    # more clearly (now no need to store this stuff)
-                    cc_nums = []
-                    draw_type = config.DRAW_NR
-                else:
-                    # Otherwise, actually store the filtered cc nums. Save a
-                    # copy of the original cc nums for showing in the
-                    # currently-drawn text, etc (but don't bother if filtering
-                    # didn't change anything)
-                    if cc_nums != filtered_cc_nums:
-                        orig_cc_nums = list(cc_nums)
-                    cc_nums = filtered_cc_nums
-
-            elif draw_type == config.DRAW_ALL:
-                # just draw all nonredundant components
-                #
-                # use a different draw type than DRAW_CCS, which will let us
-                # show a more concise summary of what is drawn than listing out
-                # something like "#1; #3; #5; ..." (and a more accurate summary
-                # than saying #1 -- |Components| like we would for DRAW_ALL).
-                #
-                # (also, no need to set "cc_nums = ag.get_nr_cc_nums()", since
-                # the AssemblyGraph will just see DRAW_NR and know to look
-                # those up)
-                draw_type = config.DRAW_NR
-
-        # cc_nums has to be JSON-serializable (it might be a set at this point)
-        # (and don't worry; if we are not using DRAW_CCS, then this will just
+        # These have to be JSON-serializable (they may be sets at this point)
+        # (and don't worry; if we are not using DRAW_CCS, then these will just
         # be []. and that's beautiful. not really)
         cc_nums = list(cc_nums)
+        orig_cc_nums = list(orig_cc_nums)
 
         # Okay, now we've done enough checks that this request to draw the
         # graph seems good.

--- a/metagenomescope/main.py
+++ b/metagenomescope/main.py
@@ -2675,10 +2675,9 @@ def run(
 
         if not show_patts:
             opts = copy.deepcopy(ui_config.MODIFIER_SETTINGS_OPTIONS)
-            for o in opts:
-                if o["value"] == ui_config.DO_RECURSIVE_LAYOUT:
-                    o["disabled"] = True
-                    break
+            ui_utils.disable_dcc_checklist_option(
+                opts, ui_config.DO_RECURSIVE_LAYOUT
+            )
         else:
             opts = ui_config.MODIFIER_SETTINGS_OPTIONS
 

--- a/metagenomescope/misc_utils.py
+++ b/metagenomescope/misc_utils.py
@@ -40,6 +40,38 @@ def verify_subset(s1, s2, custom_message=None):
         raise WeirdError(msg)
 
 
+def safe_list_discard(t, e):
+    """Tries to remove a single occurrence of element e from list t.
+
+    If e is not in t, then this will not raise an error. Otherwise,
+    one occurrence of e in t will be removed (which occurrence it is
+    is controlled by list.remove(); as of writing, it should be the first
+    occurrence).
+
+    Parameters
+    ----------
+    t: list
+
+    e: element
+
+    Returns
+    -------
+    None
+        (This modifies t in-place.)
+
+    Notes
+    -----
+    Tragically, there really isn't an elegant and efficient way to do this
+    using just the Python standard library (at least according to
+    https://old.reddit.com/r/Python/comments/1spcsq). Hence this being its
+    own function lol
+    """
+    try:
+        t.remove(e)
+    except ValueError:
+        pass
+
+
 def get_basename_if_fp(fp):
     if fp is None:
         return None

--- a/metagenomescope/tests/graph/test_draw_results.py
+++ b/metagenomescope/tests/graph/test_draw_results.py
@@ -7,7 +7,7 @@ from metagenomescope.errors import WeirdError
 def test_init_empty():
     dr = DrawResults({}, [ui_config.SHOW_PATTERNS])
     assert dr.region2layout == {}
-    assert dr.draw_settings == [ui_config.SHOW_PATTERNS]
+    assert dr.scope_settings == [ui_config.SHOW_PATTERNS]
     assert dr.incl_patterns
     assert dr.layouts_given
     assert dr.num_full_nodes == 0
@@ -20,7 +20,7 @@ def test_init_nolayout_subgraph():
     sg = Subgraph(5, "sg5", [b], [], [])
     dr = DrawResults({sg: None}, [])
     assert dr.region2layout == {sg: None}
-    assert dr.draw_settings == []
+    assert dr.scope_settings == []
     assert not dr.incl_patterns
     assert not dr.layouts_given
     assert dr.num_full_nodes == 1
@@ -69,10 +69,10 @@ def test_add_simple():
     dr2 = DrawResults({sg6: None}, [])
     drs = dr + dr2
     assert drs.region2layout == {sg5: None, sg6: None}
-    assert drs.draw_settings == []
+    assert drs.scope_settings == []
 
 
-def test_add_with_draw_settings():
+def test_add_with_scope_settings():
     b = Node(0, "B", {"orientation": config.FWD})
     sg5 = Subgraph(5, "sg5", [b], [], [])
 
@@ -83,7 +83,7 @@ def test_add_with_draw_settings():
     dr2 = DrawResults({sg6: None}, [ui_config.SHOW_PATTERNS])
     drs = dr + dr2
     assert drs.region2layout == {sg5: None, sg6: None}
-    assert drs.draw_settings == [ui_config.SHOW_PATTERNS]
+    assert drs.scope_settings == [ui_config.SHOW_PATTERNS]
 
 
 def test_add_duplicate_region():
@@ -97,7 +97,7 @@ def test_add_duplicate_region():
     assert "Regions present in multiple DrawResults" in str(ei.value)
 
 
-def test_add_incompatible_draw_settings():
+def test_add_incompatible_scope_settings():
     b = Node(0, "B", {"orientation": config.FWD})
     sg5 = Subgraph(5, "sg5", [b], [], [])
 
@@ -108,7 +108,7 @@ def test_add_incompatible_draw_settings():
     dr2 = DrawResults({sg6: None}, [])
     with pytest.raises(WeirdError) as ei:
         dr + dr2
-    assert "Incompatible draw settings" in str(ei.value)
+    assert "Incompatible scope settings" in str(ei.value)
 
 
 def test_get_sorted_regions_subgraphs():

--- a/metagenomescope/tests/graph/test_subgraph.py
+++ b/metagenomescope/tests/graph/test_subgraph.py
@@ -136,6 +136,7 @@ def test_to_cyjs_clientside_layout():
     _, cc, _, _, _ = layout_test_utils.get_cycle_with_tip_data()
     dr = cc.to_cyjs(
         [ui_config.SHOW_PATTERNS],
+        [],
         ui_config.LAYOUT_DAGRE,
         {},
     )
@@ -148,6 +149,7 @@ def test_to_cyjs_gv_layout():
     ag, cc, n1, n2, n3 = layout_test_utils.get_cycle_with_tip_data()
     dr = cc.to_cyjs(
         [ui_config.SHOW_PATTERNS],
+        [],
         ui_config.LAYOUT_DOT,
         {ui_config.LAYOUT_DOT: {"ranksep": 3}},
     )

--- a/metagenomescope/tests/layout/test_layout.py
+++ b/metagenomescope/tests/layout/test_layout.py
@@ -38,6 +38,7 @@ def test_layout_cycle_with_tip_nonrecursive():
     lay = Layout(
         cc,
         [ui_config.SHOW_PATTERNS],
+        [],
         ui_config.LAYOUT_DOT,
         {ui_config.LAYOUT_DOT: {"ranksep": 3}},
     )
@@ -47,13 +48,13 @@ def test_layout_cycle_with_tip_nonrecursive():
 def test_layout_bad_algorithm():
     _, cc, _, _, _ = utils.get_cycle_with_tip_data()
     with pytest.raises(WeirdError) as ei:
-        Layout(cc, [ui_config.SHOW_PATTERNS], "badalg", {})
+        Layout(cc, [ui_config.SHOW_PATTERNS], [], "badalg", {})
     assert str(ei.value) == "badalg not mapped to a Graphviz program?"
 
     # even "recognized" algorithms that don't refer to graphviz progs
     # should still trigger an error if you call Layout() with them directly
     with pytest.raises(WeirdError) as ei:
-        Layout(cc, [ui_config.SHOW_PATTERNS], ui_config.LAYOUT_DAGRE, {})
+        Layout(cc, [ui_config.SHOW_PATTERNS], [], ui_config.LAYOUT_DAGRE, {})
     assert (
         str(ei.value)
         == f"{ui_config.LAYOUT_DAGRE} not mapped to a Graphviz program?"
@@ -61,10 +62,15 @@ def test_layout_bad_algorithm():
 
 
 def test_layout_to_solid_dot():
+    # this example is a bit silly since we won't really call .to_solid_dot()
+    # on a layout outside of the context of the recursive layout procedure.
+    # but let's do it anyway just to test this without the added complexity of
+    # the recursive stuff at this point
     ag, cc, n1, n2, n3 = utils.get_cycle_with_tip_data()
     lay = Layout(
         cc,
         [ui_config.SHOW_PATTERNS],
+        [],
         ui_config.LAYOUT_DOT,
         {ui_config.LAYOUT_DOT: {"ranksep": 3}},
     )

--- a/metagenomescope/tests/test_misc_utils.py
+++ b/metagenomescope/tests/test_misc_utils.py
@@ -66,6 +66,30 @@ def test_verify_subset_custom_message():
     assert str(ei.value) == "floompty"
 
 
+def test_safe_list_discard():
+    t = [1, 2, 3, 4]
+    mu.safe_list_discard(t, 1)
+    assert t == [2, 3, 4]
+    mu.safe_list_discard(t, 1)
+    assert t == [2, 3, 4]
+    mu.safe_list_discard(t, 100)
+    assert t == [2, 3, 4]
+    mu.safe_list_discard(t, 3)
+    assert t == [2, 4]
+
+
+def test_safe_list_discard_multiple_occurrences():
+    t = [1, 2, 3, 4, 1, 1, 1, 2]
+    mu.safe_list_discard(t, 1)
+    assert t == [2, 3, 4, 1, 1, 1, 2]
+    mu.safe_list_discard(t, 2)
+    assert t == [3, 4, 1, 1, 1, 2]
+    mu.safe_list_discard(t, 1)
+    assert t == [3, 4, 1, 1, 2]
+    mu.safe_list_discard(t, 2)
+    assert t == [3, 4, 1, 1]
+
+
 def test_get_basename_if_fp():
     assert mu.get_basename_if_fp(None) is None
     assert mu.get_basename_if_fp("abcdef.ghjil") == "abcdef.ghjil"

--- a/metagenomescope/tests/test_ui_utils.py
+++ b/metagenomescope/tests/test_ui_utils.py
@@ -670,7 +670,24 @@ def test_get_curr_drawn_text_nr_multiple():
     )
 
 
-def test_get_curr_drawn_text_cc_nr_filtering():
+def test_get_curr_drawn_text_cc_nr_filtering_single():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert (
+        uu.get_curr_drawn_text(
+            {
+                "draw_type": config.DRAW_CCS,
+                "cc_nums": [1],
+                # orig_cc_nums should be empty UNLESS it differs
+                # from cc_nums
+                "orig_cc_nums": [],
+            },
+            ag,
+        )
+        == "#1"
+    )
+
+
+def test_get_curr_drawn_text_cc_nr_filtering_multiple():
     ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
     assert (
         uu.get_curr_drawn_text(
@@ -682,6 +699,18 @@ def test_get_curr_drawn_text_cc_nr_filtering():
             ag,
         )
         == "#3 \u2013 4; filtered to 1 nonredundant component"
+    )
+    assert (
+        uu.get_curr_drawn_text(
+            {
+                "draw_type": config.DRAW_CCS,
+                # order shouldn't matter...
+                "cc_nums": [3, 1],
+                "orig_cc_nums": [3, 1, 2, 4],
+            },
+            ag,
+        )
+        == "#1 \u2013 4; filtered to 2 nonredundant components"
     )
 
 

--- a/metagenomescope/tests/test_ui_utils.py
+++ b/metagenomescope/tests/test_ui_utils.py
@@ -502,7 +502,8 @@ def test_get_curr_drawn_text_cc_single():
     ag = AssemblyGraph("metagenomescope/tests/input/one.gml")
     assert (
         uu.get_curr_drawn_text(
-            {"draw_type": config.DRAW_CCS, "cc_nums": [1]}, ag
+            {"draw_type": config.DRAW_CCS, "cc_nums": [1], "orig_cc_nums": []},
+            ag,
         )
         == "#1"
     )
@@ -510,7 +511,12 @@ def test_get_curr_drawn_text_cc_single():
     ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
     assert (
         uu.get_curr_drawn_text(
-            {"draw_type": config.DRAW_CCS, "cc_nums": [3]}, ag
+            {
+                "draw_type": config.DRAW_CCS,
+                "cc_nums": [3],
+                "orig_cc_nums": [],
+            },
+            ag,
         )
         == "#3"
     )
@@ -520,7 +526,12 @@ def test_get_curr_drawn_text_cc_multi():
     ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
     assert (
         uu.get_curr_drawn_text(
-            {"draw_type": config.DRAW_CCS, "cc_nums": [3, 1, 4]}, ag
+            {
+                "draw_type": config.DRAW_CCS,
+                "cc_nums": [3, 1, 4],
+                "orig_cc_nums": [],
+            },
+            ag,
         )
         == "#1; #3 \u2013 4"
     )
@@ -553,7 +564,22 @@ def test_get_curr_drawn_text_nr_multiple():
     ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
     assert (
         uu.get_curr_drawn_text({"draw_type": config.DRAW_NR}, ag)
-        == "2 / 4 nonredundant components"
+        == "#1 \u2013 4; filtered to 2 nonredundant components"
+    )
+
+
+def test_get_curr_drawn_text_cc_nr_filtering():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert (
+        uu.get_curr_drawn_text(
+            {
+                "draw_type": config.DRAW_CCS,
+                "cc_nums": [3],
+                "orig_cc_nums": [3, 4],
+            },
+            ag,
+        )
+        == "#3 \u2013 4; filtered to 1 nonredundant component"
     )
 
 

--- a/metagenomescope/tests/test_ui_utils.py
+++ b/metagenomescope/tests/test_ui_utils.py
@@ -880,6 +880,68 @@ def test_summarize_undrawn_nodes_multi_all_undrawn_diff_ccs():
     assert recorded_nodes == {"3", "-3"}
 
 
+def test_disable_dcc_checklist_option():
+    opts = [
+        {
+            "label": "Just nonredundant components",
+            "value": "nr",
+        },
+        {"label": "oooh i'm a label", "value": "slayyybel"},
+    ]
+    uu.disable_dcc_checklist_option(opts, "slayyybel")
+    assert opts == [
+        {
+            "label": "Just nonredundant components",
+            "value": "nr",
+        },
+        {
+            "label": "oooh i'm a label",
+            "value": "slayyybel",
+            "disabled": True,
+        },
+    ]
+
+
+def test_disable_dcc_checklist_option_just_one_option():
+    opts = [
+        {"label": "oooh i'm a label", "value": "slayyybel"},
+    ]
+    uu.disable_dcc_checklist_option(opts, "slayyybel")
+    assert opts == [
+        {
+            "label": "oooh i'm a label",
+            "value": "slayyybel",
+            "disabled": True,
+        },
+    ]
+
+
+def test_disable_dcc_checklist_option_multiple_values_to_disable():
+    opts = [
+        {"label": "label1", "value": "val"},
+        {"label": "label2", "value": "val"},
+        {"label": "label3", "value": "val"},
+        {"label": "label4", "value": "val"},
+    ]
+    uu.disable_dcc_checklist_option(opts, "val")
+    # just the first occurrence of "val" should be disabled.
+    assert opts == [
+        {"label": "label1", "value": "val", "disabled": True},
+        {"label": "label2", "value": "val"},
+        {"label": "label3", "value": "val"},
+        {"label": "label4", "value": "val"},
+    ]
+
+
+def test_disable_dcc_checklist_option_missing_value():
+    opts = [
+        {"label": "oooh i'm a label", "value": "slayyybel"},
+    ]
+    with pytest.raises(WeirdError) as ei:
+        uu.disable_dcc_checklist_option(opts, "evil")
+    assert "no val evil" in str(ei.value)
+
+
 def test_get_badge_color():
     assert uu.get_badge_color(0) == css_config.BADGE_ZERO_COLOR
     assert (

--- a/metagenomescope/tests/test_ui_utils.py
+++ b/metagenomescope/tests/test_ui_utils.py
@@ -492,6 +492,101 @@ def test_nrfilter_draw_request_all():
     ) == (config.DRAW_NR, set(), set())
 
 
+def test_nrfilter_draw_request_all_no_nr():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request([], config.DRAW_ALL, set(), ag) == (
+        config.DRAW_ALL,
+        set(),
+        set(),
+    )
+
+
+def test_nrfilter_draw_request_ccs_filtering_changes_ccs():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_CCS, {1, 2, 3}, ag
+    ) == (config.DRAW_CCS, {1, 3}, {1, 2, 3})
+
+
+def test_nrfilter_draw_request_ccs_filtering_doesnt_change_ccs():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+
+    # at least as of writing, cc 3 is a single + node and cc 4 is a single
+    # - node. Thus, cc 3 is represented in ag.nr_cc_nums, and is what we
+    # would show when drawing all ccs but just the NR ones.
+
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_CCS, {1, 3}, ag
+    ) == (config.DRAW_CCS, {1, 3}, set())
+
+    # However! If the user requests cc 4 directly, without also requesting
+    # cc 3, then we should just show cc 4 -- even though it is the
+    # "non-canonical" version of the pair of redundant components [3, 4].
+    #
+    # NOTE: The behavior that the "positive" version of a component comes
+    # earlier (i.e. that cc 3 has the + node and cc 4 having the - node,
+    # instead of it being the other way around) is not guaranteed, I think.
+    # It should always be the case (should this break it will cause at
+    # least cause test_nrfilter_draw_request_ccs_filtering_changes_ccs() to
+    # fail); see https://github.com/marbl/MetagenomeScope/issues/451 ...
+    #
+    # Anyway, whether 3 or 4 is the + one, requesting only 3 or 4 (without
+    # the other) means that it should be retained after NR filtering.
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_CCS, {1, 4}, ag
+    ) == (config.DRAW_CCS, {1, 4}, set())
+
+
+def test_nrfilter_draw_request_ccs_filtering_fancy():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_CCS, {1, 3, 4}, ag
+    ) == (config.DRAW_CCS, {1, 3}, {1, 3, 4})
+
+    # Test the case where the user requests every component.
+    # Previously we detected this and changed the draw type to
+    # DRAW_NR, but I think it is better here to just keep it as
+    # DRAW_CCS (makes the "currently drawn" stuff better reflect
+    # what the user typed in).
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_CCS, {1, 2, 3, 4}, ag
+    ) == (config.DRAW_CCS, {1, 3}, {1, 2, 3, 4})
+
+
+def test_nrfilter_draw_request_ccs_no_nr():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request([], config.DRAW_CCS, {1, 3, 4}, ag) == (
+        config.DRAW_CCS,
+        {1, 3, 4},
+        set(),
+    )
+
+
+def test_nrfilter_draw_request_around_doesnt_change_anything():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_AROUND, set(), ag
+    ) == (config.DRAW_AROUND, set(), set())
+
+    assert uu.nrfilter_draw_request([], config.DRAW_AROUND, set(), ag) == (
+        config.DRAW_AROUND,
+        set(),
+        set(),
+    )
+
+
+def test_nrfilter_draw_request_bad_draw_type():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    with pytest.raises(WeirdError) as ei:
+        uu.nrfilter_draw_request([ui_config.NR_CCS], config.DRAW_NR, set(), ag)
+    assert str(ei.value) == 'Unrecognized draw type: "nr"'
+
+    with pytest.raises(WeirdError) as ei:
+        uu.nrfilter_draw_request([ui_config.NR_CCS], "blorbo :3", set(), ag)
+    assert str(ei.value) == 'Unrecognized draw type: "blorbo :3"'
+
+
 def test_get_curr_drawn_text_all_multicc():
     ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
     assert (

--- a/metagenomescope/tests/test_ui_utils.py
+++ b/metagenomescope/tests/test_ui_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from metagenomescope import ui_utils as uu, config, css_config
+from metagenomescope import ui_utils as uu, config, css_config, ui_config
 from metagenomescope.graph import AssemblyGraph
 from metagenomescope.errors import UIError, WeirdError
 
@@ -483,6 +483,13 @@ def test_fmt_num_ranges():
     assert uu.fmt_num_ranges(
         [1234, 3, 4, 5, 100, 1235, 1237, 999999], thousands_seps=False
     ) == ("#3 \u2013 5; #100; #1234 \u2013 1235; #1237; #999999")
+
+
+def test_nrfilter_draw_request_all():
+    ag = AssemblyGraph("metagenomescope/tests/input/sample1.gfa")
+    assert uu.nrfilter_draw_request(
+        [ui_config.NR_CCS], config.DRAW_ALL, set(), ag
+    ) == (config.DRAW_NR, set(), set())
 
 
 def test_get_curr_drawn_text_all_multicc():

--- a/metagenomescope/ui_config.py
+++ b/metagenomescope/ui_config.py
@@ -16,10 +16,10 @@ SCOPE_SETTINGS_OPTIONS = [
         "label": "Just nonredundant components",
         "value": NR_CCS,
     },
-    {
-        "label": "Split strand-tangled components",
-        "value": SPLIT_STRANDTANGLED,
-    },
+    # {
+    #     "label": "Split strand-tangled components",
+    #     "value": SPLIT_STRANDTANGLED,
+    # },
     {
         "label": "Show patterns",
         "value": SHOW_PATTERNS,

--- a/metagenomescope/ui_config.py
+++ b/metagenomescope/ui_config.py
@@ -5,9 +5,9 @@ from dash import html
 ###############################################################################
 
 NR_CCS = "nrccs"
-SPLIT_STRANDTANGLED = "detangle"
+# SPLIT_STRANDTANGLED = "detangle"
 SHOW_PATTERNS = "patterns"
-DEFAULT_SCOPE_SETTINGS = [NR_CCS, SPLIT_STRANDTANGLED, SHOW_PATTERNS]
+DEFAULT_SCOPE_SETTINGS = [NR_CCS, SHOW_PATTERNS]
 
 DOT_TEXT = html.Span("dot", style={"font-style": "italic"})
 

--- a/metagenomescope/ui_config.py
+++ b/metagenomescope/ui_config.py
@@ -4,35 +4,33 @@ from dash import html
 # Default drawing settings
 ###############################################################################
 
-# values in the draw settings checklist
+NR_CCS = "nrccs"
+SPLIT_STRANDTANGLED = "detangle"
 SHOW_PATTERNS = "patterns"
-DO_LAYOUT_ANIMATION = "animate"
-DO_RECURSIVE_LAYOUT = "recursive"
-USE_GV_PORTS = "ports"
-
-# by default, which draw settings are enabled?
-DEFAULT_SHOW_PATTERNS = True
-DEFAULT_DO_LAYOUT_ANIMATION = True
-DEFAULT_DO_RECURSIVE_LAYOUT = False
-DEFAULT_USE_GV_PORTS = False
-
-DEFAULT_DRAW_SETTINGS = []
-if DEFAULT_SHOW_PATTERNS:
-    DEFAULT_DRAW_SETTINGS.append(SHOW_PATTERNS)
-if DEFAULT_DO_LAYOUT_ANIMATION:
-    DEFAULT_DRAW_SETTINGS.append(DO_LAYOUT_ANIMATION)
-if DEFAULT_DO_RECURSIVE_LAYOUT:
-    DEFAULT_DRAW_SETTINGS.append(DO_RECURSIVE_LAYOUT)
-if DEFAULT_USE_GV_PORTS:
-    DEFAULT_DRAW_SETTINGS.append(USE_GV_PORTS)
+DEFAULT_SCOPE_SETTINGS = [NR_CCS, SPLIT_STRANDTANGLED, SHOW_PATTERNS]
 
 DOT_TEXT = html.Span("dot", style={"font-style": "italic"})
 
-DRAW_SETTINGS_OPTIONS = [
+SCOPE_SETTINGS_OPTIONS = [
+    {
+        "label": "Just nonredundant components",
+        "value": NR_CCS,
+    },
+    {
+        "label": "Split strand-tangled components",
+        "value": SPLIT_STRANDTANGLED,
+    },
     {
         "label": "Show patterns",
         "value": SHOW_PATTERNS,
     },
+]
+
+DO_RECURSIVE_LAYOUT = "recursive"
+USE_GV_PORTS = "ports"
+DO_LAYOUT_ANIMATION = "animate"
+
+MODIFIER_SETTINGS_OPTIONS = [
     {
         "label": html.Span(
             [
@@ -58,6 +56,8 @@ DRAW_SETTINGS_OPTIONS = [
         "value": DO_LAYOUT_ANIMATION,
     },
 ]
+DEFAULT_MODIFIER_SETTINGS = [DO_LAYOUT_ANIMATION]
+
 
 COLORING_RANDOM = "random"
 COLORING_UNIFORM = "uniform"

--- a/metagenomescope/ui_config.py
+++ b/metagenomescope/ui_config.py
@@ -4,7 +4,7 @@ from dash import html
 # Default drawing settings
 ###############################################################################
 
-NR_CCS = "nrccs"
+NR_CCS = "nr"
 # SPLIT_STRANDTANGLED = "detangle"
 SHOW_PATTERNS = "patterns"
 DEFAULT_SCOPE_SETTINGS = [NR_CCS, SHOW_PATTERNS]

--- a/metagenomescope/ui_utils.py
+++ b/metagenomescope/ui_utils.py
@@ -842,7 +842,15 @@ def get_curr_drawn_text(done_flushing, ag):
         t = _get_range_text_from_bounds_only(1, len(ag.components))
 
     elif draw_type == config.DRAW_CCS:
-        t = fmt_num_ranges(done_flushing["cc_nums"])
+        if len(done_flushing["orig_cc_nums"]) > 0:
+            t = fmt_num_ranges(done_flushing["orig_cc_nums"])
+            drawn_cc_ct = len(done_flushing["cc_nums"])
+            t += (
+                "; filtered to "
+                f"{pluralize(drawn_cc_ct, 'nonredundant component')}"
+            )
+        else:
+            t = fmt_num_ranges(done_flushing["cc_nums"])
 
     elif draw_type == config.DRAW_NR:
         nrccs = list(ag.get_nr_cc_nums())
@@ -850,7 +858,8 @@ def get_curr_drawn_text(done_flushing, ag):
         if nrct == 1:
             t = fmt_num_ranges(nrccs)
         else:
-            t = f"{nrct:,} / {len(ag.components):,} nonredundant components"
+            t = _get_range_text_from_bounds_only(1, len(ag.components))
+            t += f"; filtered to {pluralize(nrct, 'nonredundant component')}"
 
     elif draw_type == config.DRAW_AROUND:
         d = done_flushing["around_dist"]

--- a/metagenomescope/ui_utils.py
+++ b/metagenomescope/ui_utils.py
@@ -6,7 +6,7 @@ import dash_bootstrap_components as dbc
 import dash_ag_grid as dag
 from collections import defaultdict
 from dash import html, dcc
-from . import css_config, ui_config, config, name_utils
+from . import css_config, ui_config, config, name_utils, misc_utils
 from .errors import UIError, WeirdError
 from .gap import Gap
 
@@ -1030,6 +1030,40 @@ def get_screenshot_basename():
     return time.strftime("mgsc-%Y%m%dT%H%M%S")
 
 
+def disable_dcc_checklist_option(options, value_to_disable):
+    """Disables an option in a dcc.Checklist.
+
+    Parameters
+    ----------
+    options: list of dict
+        Basically this is just the format expected by dcc.Checklist. The
+        dicts are stuff like {"label": "My option", "value": "o"}.
+
+    value_to_disable: str
+        Corresponds to a value for which we will disable an option (by
+        setting "disabled": True).
+
+    Raises
+    ------
+    WeirdError
+        If no option with value value_to_disable exists in options.
+
+    Notes
+    -----
+    Values in these checklists should be unique (right???). In the terrible
+    event that for some reason "options" has multiple options with a value of
+    value_to_disable, we will only disable the first option with this value.
+    """
+    nothing_disabled = True
+    for o in options:
+        if o["value"] == value_to_disable:
+            o["disabled"] = True
+            nothing_disabled = False
+            break
+    if nothing_disabled:
+        raise WeirdError(f"Opts {options} has no val {value_to_disable}?")
+
+
 def get_selected_ele_html(eleType, columnDefs, extra_attrs=[]):
     for a in extra_attrs:
         # Do we know in advance a human-readable name and a good type for
@@ -1393,18 +1427,10 @@ def get_layout_options_tab(
     # "just show nonredundant ccs" option here. We COULD hide it entirely but
     # I think disabling gives a clearer user experience.
     if not (orientation_in_name and multiple_ccs):
-        for o in scope_options:
-            if o["value"] == ui_config.NR_CCS:
-                o["disabled"] = True
-                # tragically there isn't an elegant way to remove an element
-                # from a list but not raise an error (at least according to
-                # https://old.reddit.com/r/Python/comments/1spcsq) so sure
-                # let's just do this the lazy way
-                try:
-                    default_scope_settings.remove(ui_config.NR_CCS)
-                except ValueError:
-                    pass
-                break
+        disable_dcc_checklist_option(scope_options, ui_config.NR_CCS)
+        # Go a step further: ensure that this option is turned off entirely for
+        # theses kinds of graphs.
+        misc_utils.safe_list_discard(default_scope_settings, ui_config.NR_CCS)
 
     return html.Div(
         [

--- a/metagenomescope/ui_utils.py
+++ b/metagenomescope/ui_utils.py
@@ -1171,6 +1171,127 @@ def use_gv_ports(modifier_settings):
     return ui_config.USE_GV_PORTS in modifier_settings
 
 
+def nrfilter_draw_request(scope_settings, draw_type, cc_nums, ag):
+    """Filters a draw request to remove nonredundant components.
+
+    Parameters
+    ----------
+    scope_settings: list of str
+        Corresponds to the scope settings checklist (as of writing, this
+        is located in the Layout tab of the drawing options dialog).
+
+    draw_type: str
+        Should be one of {DRAW_ALL, DRAW_CCS, DRAW_AROUND} from config.py.
+        Indicates what sort of drawing method the user selected.
+
+    cc_nums: set of int
+        If draw_type == DRAW_CCS, this should be a set of the corresponding
+        component size ranks. Otherwise, this doesn't matter (I think it
+        will default to an empty list in practice).
+
+    ag: metagenomescope.graph.AssemblyGraph
+        AssemblyGraph object representing the graph that this MetagenomeScope
+        instance is visualizing things for.
+
+    Returns
+    -------
+    draw_type, cc_nums, orig_cc_nums: str, set of int, set of int
+        draw_type represents the drawing method we've decided to use for this
+        request. Should be one of {DRAW_ALL, DRAW_CCS, DRAW_AROUND, DRAW_NR}.
+        This may be different from the input draw_type.
+
+        cc_nums represents the component numbers to *actually* draw. This may
+        be a subset of what was requested. If the output draw_type is not
+        DRAW_CCS, this will be unchanged from the input.
+
+        If cc_nums ends up being filtered -- and if the output draw_type
+        remains as DRAW_CCS -- then orig_cc_nums will be set to what the input
+        cc_nums was. This is so that we can display cleaner summaries of what
+        the user requested (e.g. "10-100" instead of "10; 12; 14; ...").
+        If these conditions are not met, then this will be an empty set.
+
+    Notes
+    -----
+    It is possible, if the input draw_type is DRAW_CCS, to check if the set
+    of filtered component numbers is equal to ag.nr_cc_nums -- and, if so,
+    to just switch the output draw_type to DRAW_NR. This could happen if
+    e.g. the user requests we draw components "1-" or something like that.
+
+    However! I am not sure I like this, because then the info about what
+    is currently drawn can change: e.g. for the E. coli test dataset (61
+    components), where ccs 60 and 61 are twins (+278 and -278 respectively),
+    requesting ccs "1-60" is identical to requesting "1-61", and so even
+    "1-60" will be shown in the currently-drawn text as "1-61; filtered ...".
+    Even though the MEANING is the same I don't like changing what the user
+    sees if I can help it, right? I dunno.
+
+    (Anyway so TLDR we don't bother doing that particular draw type change even
+    though it might save us some storage space in the application.)
+    """
+    orig_cc_nums = set()
+    if nr_ccs(scope_settings):
+        # Okay, we know we should filter the draw request to remove NR CCs
+
+        if draw_type == config.DRAW_CCS:
+            # draw just the components in the list, but also remove pairs
+            # of redundant components. If both a component and its twin
+            # are in the list, then draw whichever one of the two is in
+            # ag.nr_cc_nums.
+            filtered_cc_nums = set()
+            for ccn in cc_nums:
+                if ccn in ag.nr_cc_nums:
+                    filtered_cc_nums.add(ccn)
+                else:
+                    # Even if ccn is not in ag.nr_cc_nums (i.e. it has a
+                    # twin that IS in ag.nr_cc_nums): if its twin is not in
+                    # cc_nums (i.e. it was not explicitly requested), then
+                    # draw ccn
+                    if ag.ccnum2twinccnum[ccn] not in cc_nums:
+                        filtered_cc_nums.add(ccn)
+                    # if we've made it here, both ccn and its twin were
+                    # explicitly requested (i.e. in cc_nums), so ignore ccn
+                    # in favor of its twin in ag.nr_cc_nums
+
+            # CASE 1: we are using NR filtering for some set of components.
+            if cc_nums != filtered_cc_nums:
+                # Some filtering occurred -- meaning that the set of input
+                # components is different from the set of components to be
+                # drawn. Thus, store the input components for reference.
+                orig_cc_nums = cc_nums
+            cc_nums = filtered_cc_nums
+
+        elif draw_type == config.DRAW_ALL:
+            # CASE 2: we are using NR filtering, and the user requested we draw
+            # all components. Use DRAW_NR to indicate that we should just draw
+            # all nonredundant components. (Originally this was the only option
+            # available for drawing nonredundant stuff, so it is already very
+            # fleshed out.)
+            #
+            # Using a different draw type than DRAW_CCS, lets us show a more
+            # concise summary of what is drawn than listing out something like
+            # "#1; #3; #5; ..." (and a more accurate summary
+            # than saying #1 -- |Components| like we would for DRAW_ALL).
+            #
+            # (also, no need to set "cc_nums = ag.get_nr_cc_nums()", since
+            # the AssemblyGraph will just see DRAW_NR and know to look
+            # those up)
+            draw_type = config.DRAW_NR
+
+        elif draw_type == config.DRAW_AROUND:
+            # CASE 3: we are using NR filtering, but drawing around a set of
+            # nodes. NR filtering doesn't impact this.
+            pass
+
+        else:
+            # CASE 4: the draw type is weird. throw an error.
+            raise WeirdError(f'Unrecognized draw type: "{draw_type}"')
+
+    # CASE 5 (if the nr_ccs() check was not True): we are not using NR
+    # filtering; don't change the draw type or cc_nums.
+
+    return draw_type, cc_nums, orig_cc_nums
+
+
 def get_dot_alg_descriptions():
     etal_text = html.Span(
         [html.Span("et al", style={"font-style": "italic"}), ".,"]

--- a/metagenomescope/ui_utils.py
+++ b/metagenomescope/ui_utils.py
@@ -1145,16 +1145,16 @@ def get_edge_coloring_options(ag):
     return options
 
 
-def show_patterns(draw_settings):
-    return ui_config.SHOW_PATTERNS in draw_settings
+def show_patterns(scope_settings):
+    return ui_config.SHOW_PATTERNS in scope_settings
 
 
-def do_recursive_layout(draw_settings):
-    return ui_config.DO_RECURSIVE_LAYOUT in draw_settings
+def do_recursive_layout(modifier_settings):
+    return ui_config.DO_RECURSIVE_LAYOUT in modifier_settings
 
 
-def use_gv_ports(draw_settings):
-    return ui_config.USE_GV_PORTS in draw_settings
+def use_gv_ports(modifier_settings):
+    return ui_config.USE_GV_PORTS in modifier_settings
 
 
 def get_dot_alg_descriptions():
@@ -1195,8 +1195,9 @@ def get_dot_alg_descriptions():
         ),
     ]
     if (
-        ui_config.SHOW_PATTERNS in ui_config.DEFAULT_DRAW_SETTINGS
-        and ui_config.DO_RECURSIVE_LAYOUT in ui_config.DEFAULT_DRAW_SETTINGS
+        ui_config.SHOW_PATTERNS in ui_config.DEFAULT_SCOPE_SETTINGS
+        and ui_config.DO_RECURSIVE_LAYOUT
+        in ui_config.DEFAULT_MODIFIER_SETTINGS
     ):
         dot_alg_desc_used = DOT_ALG_DESC_PATTS
     else:
@@ -1254,7 +1255,7 @@ def get_layout_options_tab(node_centric, default_dot_alg_desc):
                 ),
                 className="drawing-option-topnote",
             ),
-            html.H5("Modifiers"),
+            html.H5("What should we draw?"),
             # Eventually we can add other stuff here, e.g. "filter
             # nodes/edges with < X cov"
             #
@@ -1267,9 +1268,19 @@ def get_layout_options_tab(node_centric, default_dot_alg_desc):
             # dcc.Checklist is better.
             html.Div(
                 dcc.Checklist(
-                    options=ui_config.DRAW_SETTINGS_OPTIONS,
-                    value=ui_config.DEFAULT_DRAW_SETTINGS,
-                    id="drawSettingsChecklist",
+                    options=ui_config.SCOPE_SETTINGS_OPTIONS,
+                    value=ui_config.DEFAULT_SCOPE_SETTINGS,
+                    id="scopeSettingsChecklist",
+                ),
+                className="form-check fancyChecklistInDialog",
+            ),
+            html.Br(),
+            html.H5("How should we draw it?"),
+            html.Div(
+                dcc.Checklist(
+                    options=ui_config.MODIFIER_SETTINGS_OPTIONS,
+                    value=ui_config.DEFAULT_MODIFIER_SETTINGS,
+                    id="modifierSettingsChecklist",
                 ),
                 className="form-check fancyChecklistInDialog",
             ),
@@ -1409,7 +1420,7 @@ def get_layout_options_tab(node_centric, default_dot_alg_desc):
                 style={"text-align": "center"},
             ),
             html.Br(),
-            html.H5("Parameters"),
+            html.H5("Layout parameters"),
             html.Div(
                 [
                     dbc.InputGroup(

--- a/metagenomescope/ui_utils.py
+++ b/metagenomescope/ui_utils.py
@@ -1,5 +1,6 @@
 import re
 import time
+import copy
 import statistics
 import dash_bootstrap_components as dbc
 import dash_ag_grid as dag
@@ -1145,6 +1146,10 @@ def get_edge_coloring_options(ag):
     return options
 
 
+def nr_ccs(scope_settings):
+    return ui_config.NR_CCS in scope_settings
+
+
 def show_patterns(scope_settings):
     return ui_config.SHOW_PATTERNS in scope_settings
 
@@ -1205,7 +1210,9 @@ def get_dot_alg_descriptions():
     return DOT_ALG_DESC, DOT_ALG_DESC_PATTS, dot_alg_desc_used
 
 
-def get_layout_options_tab(node_centric, default_dot_alg_desc):
+def get_layout_options_tab(
+    node_centric, orientation_in_name, multiple_ccs, default_dot_alg_desc
+):
 
     JS_ALG_WARNING = html.P(
         [
@@ -1246,6 +1253,29 @@ def get_layout_options_tab(node_centric, default_dot_alg_desc):
         JS_ALG_WARNING,
     ]
 
+    scope_options = copy.deepcopy(ui_config.SCOPE_SETTINGS_OPTIONS)
+    default_scope_settings = copy.deepcopy(ui_config.DEFAULT_SCOPE_SETTINGS)
+    # Drawing only the nonredundant parts of the graph only makes sense if
+    # (1) there are pairs of nodes/edges X and -X in the graph (i.e.
+    # ag.orientation_in_name is True) and (2) there are multiple components.
+    #
+    # If this is NOT the case, then let's just turn off (and disable) the
+    # "just show nonredundant ccs" option here. We COULD hide it entirely but
+    # I think disabling gives a clearer user experience.
+    if not (orientation_in_name and multiple_ccs):
+        for o in scope_options:
+            if o["value"] == ui_config.NR_CCS:
+                o["disabled"] = True
+                # tragically there isn't an elegant way to remove an element
+                # from a list but not raise an error (at least according to
+                # https://old.reddit.com/r/Python/comments/1spcsq) so sure
+                # let's just do this the lazy way
+                try:
+                    default_scope_settings.remove(ui_config.NR_CCS)
+                except ValueError:
+                    pass
+                break
+
     return html.Div(
         [
             html.Div(
@@ -1268,8 +1298,8 @@ def get_layout_options_tab(node_centric, default_dot_alg_desc):
             # dcc.Checklist is better.
             html.Div(
                 dcc.Checklist(
-                    options=ui_config.SCOPE_SETTINGS_OPTIONS,
-                    value=ui_config.DEFAULT_SCOPE_SETTINGS,
+                    options=scope_options,
+                    value=default_scope_settings,
                     id="scopeSettingsChecklist",
                 ),
                 className="form-check fancyChecklistInDialog",


### PR DESCRIPTION
Closes #442. This makes #448 work better, and having this infrastructure in place will make #449 easier to implement.