### PR TITLE
Draw isolated circular nodes as literal circle shapes; increase pentagonal node area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ this format is adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1
   ([#452](https://github.com/marbl/MetagenomeScope/issues/452)).
 
 - Adjust how nodes are scaled based on length
-  ([#316](https://github.com/marbl/MetagenomeScope/issues/316)).
+  ([#316](https://github.com/marbl/MetagenomeScope/issues/316),
+  [#455](https://github.com/marbl/MetagenomeScope/issues/455)).
 
 - Draw isolated nodes with one circular edge as circle shapes, to make their
   identification at a glance clearer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ this format is adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1
 - Adjust how nodes are scaled based on length
   ([#316](https://github.com/marbl/MetagenomeScope/issues/316)).
 
+- Draw isolated nodes with one circular edge as circle shapes, to make their
+  identification at a glance clearer
+  ([#443](https://github.com/marbl/MetagenomeScope/issues/443)).
+
 - Adjust default edge widths, and vary these defaults based on whether or not
   the input graph is node-centric or not. (Node-centric graphs get thicker
   edges by default.)

--- a/metagenomescope/cy_config.py
+++ b/metagenomescope/cy_config.py
@@ -117,9 +117,63 @@ def pts2spp(pts, dx=0, mx=1, autocenter=False):
 # Shapes for "oriented" nodes (i.e. the pentagon-looking things)
 ########
 
+# The polygons for shape-polygon-points in cytoscape.js are given in this
+# kind of bounding box:
+#
+#            (0,1)
+# (-1, 1)  +---+---+ (1, 1)
+#          |       |
+#          |       |
+#          |       |
+# (-1, -1) +---+---+ (1, -1)
+#            (0,-1)
+#
+# And the pentagon shapes we use to represent nodes with a defined orientation
+# look like this. The location of the "x", i.e. the horizontal coordinate of
+# the corner, is given by PCORNER. iirc, I set this to imitate graphviz'
+# house/invhouse shapes (https://github.com/fedarko/MetagenomeScope/issues/31).
+#
+#               x
+# (-1, 1)  ******--+ (1, 1)
+#          *     * |
+#          *      *|
+#          *     * |
+# (-1, -1) ******--+ (1, -1)
+PCORNER = 0.23587
+
+# Think about the bounding box above in terms of a rectangle of width w and
+# height h. What percentage of the width occurs to the left of x, and what
+# percentage of the width occurs to the right of x?
+WFRAC_BEFORE_PCORNER = (1 + PCORNER) / 2
+WFRAC_AFTER_PCORNER = 1 - WFRAC_BEFORE_PCORNER
+
+# These percentages can be used to derive the area of this pentagon in terms
+# of (wh), i.e. in terms of the overall rectangular bounding box. This tells
+# us BY HOW MUCH the pentagon's area is less than the surrounding rectangle's
+# area.
+#
+# This should make sense intuitively, kinda.
+#
+# - The left side of the pentagon (before the x) is a rectangle with
+#   height (h) and width (WFRAC_BEFORE_PCORNER * w).
+#
+# - The right side of the pentagon (after the x) is a triangle with
+#   "base length" (h) and "height" (WFRAC_AFTER_PCORNER * w).
+#
+# Thus, the area of the left side is wh * WFRAC_BEFORE_PCORNER, and the
+# area of the right side is 1/2 * h * WFRAC_AFTER_PCORNER * w, or
+# wh * (WFRAC_AFTER_PCORNER / 2).
+#
+# Summing these areas is wh * (WFRAC_BEFORE_PCORNER + WFRAC_AFTER_PCORNER / 2),
+# which tells us that this pentagon takes up this fraction of the rectangular
+# area.
+P_AREA_FRAC = WFRAC_BEFORE_PCORNER + (WFRAC_AFTER_PCORNER / 2)
+
+ONE_OVER_P_AREA_FRAC = 1 / P_AREA_FRAC
+
 # Non-split node shapes. These should correspond to the "invhouse" / "house"
 # shapes in Graphviz: https://graphviz.org/doc/info/shapes.html#polygon
-fwd_pentagon_pts = [[-1, 1], [0.23587, 1], [1, 0], [0.23587, -1], [-1, -1]]
+fwd_pentagon_pts = [[-1, 1], [PCORNER, 1], [1, 0], [PCORNER, -1], [-1, -1]]
 rev_pentagon_pts = [[-x, y] for (x, y) in fwd_pentagon_pts]
 
 FWD_NODE_SPLITN_POLYGON_PTS = pts2spp(fwd_pentagon_pts)

--- a/metagenomescope/cy_utils.py
+++ b/metagenomescope/cy_utils.py
@@ -88,6 +88,12 @@ def get_cyjs_stylesheet(
                 "shape-polygon-points": cy_config.FWD_NODE_SPLITR_POLYGON_PTS,
             },
         },
+        {
+            "selector": "node.isolatedcircle",
+            "style": {
+                "shape": "ellipse",
+            },
+        },
         ###### Reverse-oriented nodes (pentagons pointing left)
         {
             "selector": "node.rev.splitN",

--- a/metagenomescope/graph/assembly_graph.py
+++ b/metagenomescope/graph/assembly_graph.py
@@ -591,13 +591,15 @@ class AssemblyGraph(object):
             name_utils.sanity_check_node_name(str_node_name)
             node_id = self._get_unique_id()
             data = deepcopy(self.graph.nodes[node_name])
-            new_node = Node(
-                node_id,
-                str_node_name,
-                data,
-                is_isolated_circle=graph_utils.is_isolated_circle(
+            # for edge-centric graphs, we don't care about which nodes are
+            # "isolated circles" -- the edge is the real thing we care about
+            is_isocirc = False
+            if self.node_centric:
+                is_isocirc = graph_utils.is_isolated_circle(
                     self.graph, node_name
-                ),
+                )
+            new_node = Node(
+                node_id, str_node_name, data, is_isolated_circle=is_isocirc
             )
             self.nodeid2obj[node_id] = new_node
 

--- a/metagenomescope/graph/assembly_graph.py
+++ b/metagenomescope/graph/assembly_graph.py
@@ -627,6 +627,12 @@ class AssemblyGraph(object):
             else:
                 new_node.rand_idx = next(rand_idx_generator)
 
+            # Label isolated circle nodes so that they could be drawn with
+            # special styling. The Node object doesn't really know what's in
+            # the rest of the graph, so we do this check here.
+            if graph_utils.is_isolated_circle(self.graph, node_name):
+                new_node.is_isolated_circle = True
+
         # if this is a node-centric graph and we've made it here unscathed then
         # we know for sure that all nodes have lengths, and that these are
         # stored in a data field called "length".

--- a/metagenomescope/graph/assembly_graph.py
+++ b/metagenomescope/graph/assembly_graph.py
@@ -591,7 +591,14 @@ class AssemblyGraph(object):
             name_utils.sanity_check_node_name(str_node_name)
             node_id = self._get_unique_id()
             data = deepcopy(self.graph.nodes[node_name])
-            new_node = Node(node_id, str_node_name, data)
+            new_node = Node(
+                node_id,
+                str_node_name,
+                data,
+                is_isolated_circle=graph_utils.is_isolated_circle(
+                    self.graph, node_name
+                ),
+            )
             self.nodeid2obj[node_id] = new_node
 
             self.extra_node_attrs |= set(data.keys())
@@ -626,12 +633,6 @@ class AssemblyGraph(object):
                 ].rand_idx
             else:
                 new_node.rand_idx = next(rand_idx_generator)
-
-            # Label isolated circle nodes so that they could be drawn with
-            # special styling. The Node object doesn't really know what's in
-            # the rest of the graph, so we do this check here.
-            if graph_utils.is_isolated_circle(self.graph, node_name):
-                new_node.is_isolated_circle = True
 
         # if this is a node-centric graph and we've made it here unscathed then
         # we know for sure that all nodes have lengths, and that these are

--- a/metagenomescope/graph/graph_utils.py
+++ b/metagenomescope/graph/graph_utils.py
@@ -3,6 +3,33 @@ from .. import ui_utils, name_utils, config
 from metagenomescope.errors import WeirdError, GraphParsingError
 
 
+def is_isolated_circle(g, n):
+    """Returns True if a node is isolated and has one edge to itself.
+
+    Parameters
+    ----------
+    g: nx.MultiDiGraph
+    n: int
+    """
+    nadj = g.adj[n]
+
+    # Specifically, we are checking here that:
+    # - n has outgoing edge(s) to only one node
+    # - this one node to which n has outgoing edge(s) is itself (n)
+    # - n has only ONE outgoing edge to itself
+    # - n has incoming edge(s) from only one node
+    #   (and we already know that by this point that this one node will be
+    #   itself, and that there will only be one such edge)
+    #
+    # Probably it is possible to do this faster or more elgantly but whatevs
+    return (
+        len(nadj) == 1
+        and (n in nadj)
+        and len(nadj[n]) == 1
+        and len(g.pred[n]) == 1
+    )
+
+
 def get_only_connecting_edge_uid(g, src_id, tgt_id):
     """Gets the "uid" attribute of the only edge between two nodes.
 

--- a/metagenomescope/graph/node.py
+++ b/metagenomescope/graph/node.py
@@ -110,8 +110,9 @@ class Node(object):
 
         is_isolated_circle: bool
             True if this node is in its own connected component with exactly
-            one edge to and from itself, False otherwise. This is just used as
-            of writing for adjusting how we style the node.
+            one edge to and from itself (and the graph is node-centric), False
+            otherwise. This is just used (as of writing) for adjusting how we
+            style the node.
 
         compound: bool
             If True, this node has children (i.e. it's a pattern). If False,
@@ -253,6 +254,10 @@ class Node(object):
         else:
             ndir = "unoriented"
 
+        # this should only be set to True for node-centric graphs. it
+        # shouldn't really make a difference if it is applied to a node in
+        # an edge-centric graph (they're already drawn as circles???) but let's
+        # keep this simple
         if self.is_isolated_circle:
             shapecls = "isolatedcircle"
         else:

--- a/metagenomescope/graph/node.py
+++ b/metagenomescope/graph/node.py
@@ -64,6 +64,7 @@ class Node(object):
         data,
         split=None,
         counterpart_node=None,
+        is_isolated_circle=False,
         compound=False,
     ):
         """Initializes this Node object.
@@ -106,6 +107,11 @@ class Node(object):
             should copy this new Node's relative_length and longside_proportion
             attributes. We'll also call counterpart_node.make_into_split() to
             update it.
+
+        is_isolated_circle: bool
+            True if this node is in its own connected component with exactly
+            one edge to and from itself, False otherwise. This is just used as
+            of writing for adjusting how we style the node.
 
         compound: bool
             If True, this node has children (i.e. it's a pattern). If False,
@@ -175,10 +181,12 @@ class Node(object):
 
         # Should be set by the caller if this node is in its own component with
         # just a single edge to itself. Such nodes can get special styling.
-        self.is_isolated_circle = False
+        self.is_isolated_circle = is_isolated_circle
 
         # will store info about shape, width/height, etc
-        self.layout = NodeLayout(self.split, self.data)
+        self.layout = NodeLayout(
+            self.split, self.data, is_isolated_circle=self.is_isolated_circle
+        )
 
     def __repr__(self):
         return f"Node {self.unique_id} (name: {self.name})"

--- a/metagenomescope/graph/node.py
+++ b/metagenomescope/graph/node.py
@@ -173,6 +173,10 @@ class Node(object):
         # single node. This flag is a simple way of tracking this.
         self.removed = False
 
+        # Should be set by the caller if this node is in its own component with
+        # just a single edge to itself. Such nodes can get special styling.
+        self.is_isolated_circle = False
+
         # will store info about shape, width/height, etc
         self.layout = NodeLayout(self.split, self.data)
 
@@ -241,7 +245,10 @@ class Node(object):
         else:
             ndir = "unoriented"
 
-        splitcls = f"split{'N' if self.split is None else self.split}"
+        if self.is_isolated_circle:
+            shapecls = "isolatedcircle"
+        else:
+            shapecls = f"split{'N' if self.split is None else self.split}"
 
         ele = {
             "data": {
@@ -254,7 +261,7 @@ class Node(object):
                 # for styling (maybe some memory savings?) but probs nbd
                 "ntype": cy_config.NODE_DATA_TYPE,
             },
-            "classes": f"nonpattern {ndir} {splitcls} noderand{self.rand_idx}",
+            "classes": f"nonpattern {ndir} {shapecls} noderand{self.rand_idx}",
         }
 
         ele["data"]["w"], ele["data"]["h"] = self.layout.get_dims(

--- a/metagenomescope/graph/node_layout.py
+++ b/metagenomescope/graph/node_layout.py
@@ -1,5 +1,5 @@
 import math
-from metagenomescope import config
+from metagenomescope import config, cy_config
 from metagenomescope.errors import WeirdError
 from metagenomescope.layout import layout_config, layout_utils
 
@@ -96,6 +96,12 @@ class NodeLayout(object):
                 # log100(x) = 1 occurs when x <= 100.
                 # log100(x) = 6 occurs when x >= 1e12 (aka 1 trillion).
                 r = min(max(math.log(self.length, 100), 1), 6)
+
+                # Because the area of a pentagon is only a fraction of the
+                # area of its rectangular bounding box, we multiply the area
+                # of the bounding box by 1 over this fraction to scale up the
+                # area of the pentagon to match. See cy_config.py for details.
+                area *= cy_config.ONE_OVER_P_AREA_FRAC
 
                 # A = wh, and w = rh.
                 # We thus know that A = (rh) * h = rh^2.

--- a/metagenomescope/graph/node_layout.py
+++ b/metagenomescope/graph/node_layout.py
@@ -7,7 +7,7 @@ from metagenomescope.layout import layout_config, layout_utils
 class NodeLayout(object):
     """Stores information about a node's dimensions and shape."""
 
-    def __init__(self, split, data):
+    def __init__(self, split, data, is_isolated_circle=False):
         # this can change! see update_split()
         self.split = split
 
@@ -20,6 +20,8 @@ class NodeLayout(object):
             self.length = data["length"]
         else:
             self.length = None
+
+        self.is_isolated_circle = is_isolated_circle
 
         self.set_shape()
         self.set_dims()
@@ -34,7 +36,10 @@ class NodeLayout(object):
         # these don't need to perfectly match up with the cy.js shapes. it's
         # safest if they are actually LARGER than the cy.js shapes right? or
         # like if they at least take up the same dimensions but more area.
-        if self.orientation == config.FWD:
+        if self.is_isolated_circle:
+            # ignore orientation
+            self.shape = "circle"
+        elif self.orientation == config.FWD:
             if self.split == config.SPLIT_LEFT:
                 self.shape = "rect"
             elif self.split == config.SPLIT_RIGHT:
@@ -51,21 +56,14 @@ class NodeLayout(object):
             else:
                 self.shape = "house"
         else:
-            # NOTE: Graphviz doesn't support semicircles (as of writing)
-            # but whatever rects are fine
+            # the node has no orientation (so presumably the input graph is a
+            # LJA / Flye edge-centric DOT file). Draw it as a circle or semi-
+            # circle. Graphviz doesn't support semicircles (as of writing), but
+            # whatever; just reserve a rectangular area and fill it in in cy.js
             self.shape = "rect"
 
     def set_dims(self):
         if self.length is not None:
-
-            # What should the ratio of width:height be?
-            #
-            # Adjust based on order of magnitude, to make longer sequences
-            # appear "longer" in the drawing.
-            # log100(x) = 1 occurs when x <= 100.
-            # log100(x) = 6 occurs when x >= 1e12 (aka 1 trillion).
-            r = min(max(math.log(self.length, 100), 1), 6)
-
             # Played around a lot with the various options here...
             # I'm sure there are better ways to do this.
             area = min(max(math.sqrt(self.length) / 10, 0.5), 3000)
@@ -83,11 +81,27 @@ class NodeLayout(object):
             # the range of sizes in the graph).
             ### area = min(max(self.length / 100, 1), 10_000_000)
 
-            # A = wh, and w = rh.
-            # We thus know that A = (rh) * h = rh^2.
-            # From there we can solve for A / r = h^2, and then sqrt(A/r) = h.
-            self.height = math.sqrt(area / r)
-            self.width = self.height * r
+            if self.is_isolated_circle:
+                # area of a circle = pi * radius^2
+                # flipped around, radius = sqrt(area / pi). we are setting
+                # the diameter of the circle here, which is 2 * the radius.
+                radius = math.sqrt(area / math.pi)
+                self.width = self.height = 2 * radius
+
+            else:
+                # What should the ratio of width:height be?
+                #
+                # Adjust based on order of magnitude, to make longer sequences
+                # appear "longer" in the drawing.
+                # log100(x) = 1 occurs when x <= 100.
+                # log100(x) = 6 occurs when x >= 1e12 (aka 1 trillion).
+                r = min(max(math.log(self.length, 100), 1), 6)
+
+                # A = wh, and w = rh.
+                # We thus know that A = (rh) * h = rh^2.
+                # From there we can solve for A / r = h^2 --> sqrt(A/r) = h.
+                self.height = math.sqrt(area / r)
+                self.width = self.height * r
         else:
             # mimic flye's DOT files
             self.width = layout_config.NOLENGTH_NODE_WIDTH

--- a/metagenomescope/graph/node_layout.py
+++ b/metagenomescope/graph/node_layout.py
@@ -66,7 +66,13 @@ class NodeLayout(object):
         if self.length is not None:
             # Played around a lot with the various options here...
             # I'm sure there are better ways to do this.
-            area = min(max(math.sqrt(self.length) / 10, 0.5), 3000)
+            area = min(
+                max(
+                    math.sqrt(self.length) / layout_config.NODE_AREA_DIVISOR,
+                    0.5,
+                ),
+                3000,
+            )
 
             # Alternative approach: set area as linearly proportional to seq
             # length. This actually works surprisingly well for some graphs

--- a/metagenomescope/layout/layout_config.py
+++ b/metagenomescope/layout/layout_config.py
@@ -51,6 +51,18 @@ PIXELS_PER_INCH = 54
 # The base we use when logarithmically scaling contig dimensions from length
 NODE_SCALING_LOG_BASE = 10
 
+# Divide node areas by this much. Doesn't impact NOLENGTH_NODE_* sizes;
+# only matters for nodes with a defined length.
+#
+# Because we divide *all* node areas in the drawing by this same value, it
+# doesn't really matter beyond impacting how other stuff (edge thicknesses,
+# font sizes) looks in the context of nodes.
+#
+# Previously this was 10, but then I increased it to 12 to account for how
+# pentagonal nodes are a bit bigger after the changes in
+# https://github.com/marbl/MetagenomeScope/pull/455 ...
+NODE_AREA_DIVISOR = 12
+
 NOLENGTH_NODE_WIDTH = 0.4
 NOLENGTH_NODE_HEIGHT = 0.4
 

--- a/metagenomescope/tests/graph/assembly_graph/test_init.py
+++ b/metagenomescope/tests/graph/assembly_graph/test_init.py
@@ -384,3 +384,9 @@ def test_removing_parallel_edges_yes_nongfa():
     )
     st2ct = get_srctgt2ct(ag)
     assert st2ct[("161134973", "944378205")] == 1
+
+
+def test_edge_centric_graph_nodes_not_isolated_circles():
+    ag = AssemblyGraph("metagenomescope/tests/input/flye_yeast.gv")
+    for n in ag.nodeid2obj.values():
+        assert not n.is_isolated_circle

--- a/metagenomescope/tests/graph/assembly_graph/test_init.py
+++ b/metagenomescope/tests/graph/assembly_graph/test_init.py
@@ -387,6 +387,42 @@ def test_removing_parallel_edges_yes_nongfa():
 
 
 def test_edge_centric_graph_nodes_not_isolated_circles():
+    # this graph contains some nodes that have exactly one loop edge and
+    # are in isolated components. however! they shouldn't be marked as isolated
+    # circles, because this is an edge-centric graph.
     ag = AssemblyGraph("metagenomescope/tests/input/flye_yeast.gv")
     for n in ag.nodeid2obj.values():
         assert not n.is_isolated_circle
+
+
+def test_node_centric_graph_isolated_circles():
+    # 1/-1 and 4/-4 are isolated circles, but the other nodes aren't.
+    #
+    # TECHNICALLY if you do the splitting procedure from
+    # https://github.com/marbl/MetagenomeScope/issues/449 and adjust
+    # the endport of the 2 -> -2 edge to account for how -2 is missing,
+    # then you get
+    #
+    #        +---+
+    # +----\ V   |
+    # |     | ---+
+    # +----/
+    #
+    # ... which is ARGUABLY an isolated circle? But I don't think so,
+    # because it represents a weird complex thing that isn't really a
+    # straightforward loop imo.
+    ag = AssemblyGraph("metagenomescope/tests/input/loop.gfa")
+    bn2isocirc = {}
+    for n in ag.nodeid2obj.values():
+        assert n.basename not in bn2isocirc
+        bn2isocirc[n.basename] = n.is_isolated_circle
+    assert bn2isocirc == {
+        "1": True,
+        "-1": True,
+        "2": False,
+        "-2": False,
+        "3": False,
+        "-3": False,
+        "4": True,
+        "-4": True,
+    }

--- a/metagenomescope/tests/graph/node/test_node.py
+++ b/metagenomescope/tests/graph/node/test_node.py
@@ -1,6 +1,9 @@
 import pytest
 from metagenomescope.graph.node import Node
-from metagenomescope.config import SPLIT_LEFT, SPLIT_RIGHT, FWD
+from metagenomescope import cy_config, ui_config
+from metagenomescope.layout import layout_config
+from metagenomescope.layout.layout_config import PIXELS_PER_INCH as PPI
+from metagenomescope.config import SPLIT_LEFT, SPLIT_RIGHT, FWD, REV
 from metagenomescope.errors import WeirdError
 
 
@@ -105,3 +108,107 @@ def test_to_dot_split():
         b.to_dot(indent=" ")
         == ' 0 [width=3,height=3,shape=rect,label="B-R"];\n'
     )
+
+
+def test_to_cyjs_unoriented_simple():
+    # a node in a Flye/LJA DOT file or something
+    n = Node(0, "N", {})
+    n.rand_idx = 5
+    assert n.to_cyjs([]) == {
+        "data": {
+            "id": "0",
+            "label": "N",
+            "ntype": cy_config.NODE_DATA_TYPE,
+            "w": layout_config.NOLENGTH_NODE_WIDTH * PPI,
+            "h": layout_config.NOLENGTH_NODE_HEIGHT * PPI,
+        },
+        "classes": "nonpattern unoriented splitN noderand5",
+    }
+
+
+def test_to_cyjs_fwd_is_isolated_circle():
+    n = Node(
+        1,
+        "Node1",
+        {"length": 100, "orientation": FWD},
+        is_isolated_circle=True,
+    )
+    n.rand_idx = 3
+    assert n.to_cyjs([]) == {
+        "data": {
+            "id": "1",
+            "label": "Node1",
+            "ntype": cy_config.NODE_DATA_TYPE,
+            # just get the layout dimensions from the underlying NodeLayout
+            # object; we already test that elsewhere, so I don't think it is
+            # worth going to the trouble of computing that here as well
+            # (particularly since the node scaling code will probs be updated
+            # again in the future...)
+            "w": n.layout.width * PPI,
+            "h": n.layout.height * PPI,
+        },
+        "classes": "nonpattern fwd isolatedcircle noderand3",
+    }
+
+
+def test_to_cyjs_rev_child_of_pattern():
+    n = Node(
+        1,
+        "Node1",
+        {"length": 100, "orientation": REV},
+    )
+    n.parent_id = 20
+    n.rand_idx = 1
+
+    # with scope_settings == [], this node will not have a defined
+    # parent in its Cytoscape.js data representation
+    assert n.to_cyjs([]) == {
+        "data": {
+            "id": "1",
+            "label": "Node1",
+            "ntype": cy_config.NODE_DATA_TYPE,
+            "w": n.layout.width * PPI,
+            "h": n.layout.height * PPI,
+        },
+        "classes": "nonpattern rev splitN noderand1",
+    }
+
+    # but if we are drawing the graph with patterns shown, then
+    # this node will have a parent!
+    assert n.to_cyjs([ui_config.SHOW_PATTERNS]) == {
+        "data": {
+            "id": "1",
+            "label": "Node1",
+            "ntype": cy_config.NODE_DATA_TYPE,
+            "w": n.layout.width * PPI,
+            "h": n.layout.height * PPI,
+            "parent": "20",
+        },
+        "classes": "nonpattern rev splitN noderand1",
+    }
+
+
+def test_to_cyjs_show_patterns_but_no_parent():
+    # What happens when a node has no parent but we have "show patterns"
+    # given in the scope settings anyway? The answer is that we just don't
+    # say the node has a parent, it's really not hard, this isn't complicated,
+    # but let's test it anyway i guess just out of paranoia
+    n = Node(
+        1,
+        "Node1",
+        {"length": 100, "orientation": REV},
+    )
+    n.rand_idx = 1
+
+    assert n.parent_id is None
+
+    assert n.to_cyjs([ui_config.SHOW_PATTERNS]) == {
+        "data": {
+            "id": "1",
+            "label": "Node1",
+            "ntype": cy_config.NODE_DATA_TYPE,
+            "w": n.layout.width * PPI,
+            "h": n.layout.height * PPI,
+        },
+        "classes": "nonpattern rev splitN noderand1",
+    }

--- a/metagenomescope/tests/graph/node/test_node_layout.py
+++ b/metagenomescope/tests/graph/node/test_node_layout.py
@@ -1,7 +1,8 @@
+import math
 import pytest
 from metagenomescope.graph.node import Node
 from metagenomescope.layout import layout_config
-from metagenomescope import config
+from metagenomescope import config, cy_config
 from metagenomescope.errors import WeirdError
 
 
@@ -35,6 +36,52 @@ def test_update_split_no_length():
 
     n.layout.update_split(None)
     check_nolength_node_layout(n.layout)
+
+
+def test_init_simple():
+    n = Node(0, "0", {"length": 12345, "orientation": config.FWD})
+    assert n.layout.orientation == config.FWD
+    assert n.layout.length == 12345
+    assert n.layout.shape == "invhouse"
+
+    # initial area is sqrt(12345) / 12 = ~9.26.
+    # it will then get multiplied by layout_config.ONE_OVER_P_AREA_FRAC, in
+    # order to ensure that the area within the pentagon matches this value.
+    area = (
+        math.sqrt(12345) / layout_config.NODE_AREA_DIVISOR
+    ) * cy_config.ONE_OVER_P_AREA_FRAC
+
+    # width:height ratio is log100(12345) = ~2.0457
+    whr = math.log(12345, 100)
+
+    assert n.layout.height == math.sqrt(area / whr)
+    assert n.layout.width == area / n.layout.height
+
+    # goes without saying, but...
+    assert n.layout.height * n.layout.width == area
+    assert n.layout.width == n.layout.height * whr
+
+
+def test_init_isolated_circle():
+    n = Node(
+        0,
+        "0",
+        {"length": 12345, "orientation": config.FWD},
+        is_isolated_circle=True,
+    )
+    assert n.layout.orientation == config.FWD
+    assert n.layout.length == 12345
+    assert n.layout.shape == "circle"
+
+    # area doesn't get multiplied by anything, because we can compute the
+    # area of a circle directly using A = pi*radius^2
+    # (unlike how pentagons are kind of weird)
+    area = math.sqrt(12345) / layout_config.NODE_AREA_DIVISOR
+    radius = math.sqrt(area / math.pi)
+    assert n.layout.width == 2 * radius
+    assert n.layout.height == 2 * radius
+    # this should already be guaranteed, but...
+    assert math.pi * ((n.layout.width / 2) ** 2) == pytest.approx(area)
 
 
 def test_get_dims():

--- a/metagenomescope/tests/graph/node/test_node_layout.py
+++ b/metagenomescope/tests/graph/node/test_node_layout.py
@@ -1,7 +1,40 @@
 import pytest
 from metagenomescope.graph.node import Node
 from metagenomescope.layout import layout_config
+from metagenomescope import config
 from metagenomescope.errors import WeirdError
+
+
+def check_nolength_node_layout(nlay):
+    assert nlay.orientation is None
+    assert nlay.length is None
+    assert nlay.shape == "rect"
+    assert nlay.width == layout_config.NOLENGTH_NODE_WIDTH
+    assert nlay.height == layout_config.NOLENGTH_NODE_HEIGHT
+
+
+def test_init_no_length_unsplit():
+    # Nodes with no length can happen when we visualize edge-centric
+    # graphs -- as of writing, LJA or Flye DOT files. These should
+    # be drawn as small circles, each with the same size.
+    n = Node(0, "0", {})
+    check_nolength_node_layout(n.layout)
+
+
+def test_update_split_no_length():
+    n = Node(0, "0", {})
+    check_nolength_node_layout(n.layout)
+
+    # splitting this node shouldn't change its shape or dimensions; we'll
+    # change it into a semicircle on the cytoscape.js side of things
+    n.layout.update_split(config.SPLIT_LEFT)
+    check_nolength_node_layout(n.layout)
+
+    n.layout.update_split(config.SPLIT_RIGHT)
+    check_nolength_node_layout(n.layout)
+
+    n.layout.update_split(None)
+    check_nolength_node_layout(n.layout)
 
 
 def test_get_dims():

--- a/metagenomescope/tests/graph/test_graph_utils.py
+++ b/metagenomescope/tests/graph/test_graph_utils.py
@@ -7,6 +7,33 @@ from metagenomescope.errors import WeirdError
 from metagenomescope import config
 
 
+def test_is_isolated_circle():
+    g = nx.MultiDiGraph()
+    # In this graph, just "3" is an isolated circle. The other nodes
+    # do not qualify.
+    #                    +---+
+    #      +--+   +--+   |+-+|
+    #      |  |   |  |   || ||
+    #      V  |   V  |   VV ||
+    # 1 -> 2 -+   3 -+   4 -++
+    g.add_edge(1, 2)
+    g.add_edge(2, 2)
+    g.add_edge(3, 3)
+    g.add_edge(4, 4)
+    g.add_edge(4, 4)
+    assert not gu.is_isolated_circle(g, 1)
+    assert not gu.is_isolated_circle(g, 2)
+    assert gu.is_isolated_circle(g, 3)
+    assert not gu.is_isolated_circle(g, 4)
+
+    g.add_edge(5, 4)
+    assert not gu.is_isolated_circle(g, 1)
+    assert not gu.is_isolated_circle(g, 2)
+    assert gu.is_isolated_circle(g, 3)
+    assert not gu.is_isolated_circle(g, 4)
+    assert not gu.is_isolated_circle(g, 5)
+
+
 def test_get_only_connecting_edge_uid_simple():
     g = nx.MultiDiGraph()
     g.add_edge(1, 2, uid=5)


### PR DESCRIPTION
Closes #443. Still a lot of room to go for making circular genomes/components look prettier (e.g. #294), but this should help.

## detour: pentagonal area jank

### Problem

A side effect of drawing some (but not all! usually!) nodes as circles now is that it means we have to determine if the area we use to figure out a circle's dimensions is "comparable" to the area we use to figure out a pentagon's dimensions. (Well, we don't really "have to" do anything -- I am sure you could make a case for purposefully making circles look bigger to visually emphasize them -- but I wanted to be correct.)

Since we draw pentagons as rectangles with just the top-right and bottom-right corners chopped off, the area we use to compute the width and height of a rectangle is not really the area of the "inscribed" pentagon -- it is ~80.1% of the area of the rectangle, given the shapes we use in Cytoscape.js to represent pentagonal nodes (which should match the `invhouse` / `house` shapes in Graphviz, per https://github.com/fedarko/MetagenomeScope/issues/31 aka me from ten years ago).

### Solution

So! This PR adds some logic that figures out the exact ~80.1% fraction based on the Cytoscape.js `shape-polygon-points` values. We can multiply each pentagonal node's "rectangular area" by one over this fraction, so that the actual area of the inscribed pentagon ends up being the desired area.

(And for circles we don't have to do this junk, because it is easier to go from a desired area → a radius → the diameter, which is equal to the width and height of the corresponding bounding box.)

### Testing that these areas actually hold up in practice

This PR adds a lot of tests (both that the isolated circle finding works, and that the node scaling is done correctly), but it is kind of hard to check that the area of the objects shown in Cytoscape.js to an end user of the visualization is correct -- how do we know that Cytoscape.js is scaling pentagons "uniformly"? Is "uniformly" even a word that makes sense here? (Probably not?)

Anyway, beyond these tests, I put together a test GFA file (based on [`loop.gfa`](https://github.com/sjackman/assembly-graph/blob/master/loop.gfa)):

```gfa
H	VN:Z:1.0
S	1	AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
S	2	AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACG
S	3	AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAT
S	4	AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTT
L	1	+	1	+	2M
L	2	+	2	-	2M
L	3	-	3	+	2M
L	4	-	4	-	2M
```

All of the nodes here have length 455. If we open up this graph in MetagenomeScope, then remove edges from the drawing using `getCy().remove(getCy().edges())` in the console, then we get:

<img width="3200" height="1962" alt="mgsc-20260624T185748" src="https://github.com/user-attachments/assets/159a2301-c84f-464f-a99e-698963dcb083" />

I opened this up in GIMP and verified that:

- The brown circle is inscribed within a 263 × 263 bounding box (roughly).

- Both gray pentagons have a rectangular portion which is 184 × 225, and a triangular portion inscribed within a 114 × 225 bounding box (again, roughly).

The area of the circle is `pi * ((263/2)**2)`, and the area of a pentagon is `(184*225) + (0.5 * 225 * 114)`. These values come out to ~54,325 and ~54,225, respectively, which is very close: if you increase the pentagon triangle "height" by 1, using 115 instead of 114, then you get ~54,338 -- indicating that these areas are within a "margin of error" of < 1 pixel, I think. (I think using the term "margin of error" here is kind of mathematically evil but whatever.)

So! This gives us some reassurance that Cytoscape.js is adjusting pentagonal area as we expect, and that we are drawing pentagonal and circular areas closely.


## hifiasm-meta paper ATCC graph, before these changes

<img width="3200" height="1798" alt="atcc_all_sqrt_sorted" src="https://github.com/user-attachments/assets/c022136c-38b2-4cec-8e7a-e536799b53c9" />

## hifiasm-meta paper ATCC graph, after these changes

<img width="3200" height="2016" alt="mgsc-20260624T172922" src="https://github.com/user-attachments/assets/bf9f5186-a7f8-4e75-8d39-9e470f20b056" />